### PR TITLE
setup.py use subprocess

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -37,7 +37,7 @@ version = "0.1.1rc1"
 
 init_py = open("paratext/__init__.py", "w")
 
-print >>init_py, ("""#!/usr/bin/python
+init_py.write("""#!/usr/bin/python
 __all__ = ['paratext']
 
 import core, helpers

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,10 +1,11 @@
 
-import sys, os, os.path, string
+import sys, os, os.path, string, subprocess
 import json
 
-swig_check = os.system("which swig")
-if swig_check != 0:
-    print "Error: you must install SWIG first."
+p = subprocess.Popen(["which", "swig"])
+p.communicate("")
+if p.returncode != 0:
+    print("Error: you must install SWIG first.")
     sys.exit(1)
 
 extra_link_args = []
@@ -51,12 +52,16 @@ __version__ = "%s"
 init_py.close()
 
 
-print version
+print(version)
 
-swig_cmd = 'swig -c++ -python -I../src/ -outdir ./ ../src/paratext_internal.i'
+swig_cmd = ["swig", "-c++", "-python", "-I../src/", "-outdir", "./", "../src/paratext_internal.i"]
 
-print "running swig: ", swig_cmd
-os.system(swig_cmd)
+print("running swig: ", swig_cmd)
+p = subprocess.Popen(swig_cmd)
+p.communicate("")
+if p.returncode != 0:
+    print("Error: building")
+    sys.exit(1)
 
 setup(name='paratext',
       version=version,


### PR DESCRIPTION
In the case of conda that installs `swig` in the environment I noticed that `os.system` has the issue that will not use the environment variables (`PATH`) `subprocess` does.

Also a couple of small fixed on `setup.py` to be ok with python 3. will probably solve: https://github.com/wiseio/paratext/issues/10