### PR TITLE
Support for escape characters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,15 @@ before_install:
   - python -V
   - g++ --version
 
+compiler:
+  - gcc-4.7
+  - gcc-4.9
+#  - clang-3.7
+#  - clang-3.8
+#  - clang-nightly
+#  - gcc-5.3
+#  - gcc-nightly
+
 # command to install dependencies
 install:
   - echo "install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ install:
   # Replace dep1 dep2 ... with your dependencies
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig=3.0.8
   - source activate test-environment
-  - python setup.py install
+  - cd python
+  - python setup.py build install
 
 # command to run tests
 script: nosetests tests/test_paratext.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,5 +66,11 @@ install:
   - cd ..
   - pwd
 
+before-script:
+  - export PY_PREFIX=$(python -c "import sys; print(sys.prefix)")
+  - echo $PY_PREFIX
+  - export PY_SP_DIR=$PY_PREFIX/lib/python$TRAVIS_PYTHON_VERSION/site-packages
+  - echo $PY_SP_DIR
+
 # command to run tests
 script: nosetests -xvs tests/test_paratext.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,4 +73,4 @@ before_script:
   - echo $PYTHONPATH
 
 # command to run tests
-script: nosetests -vs --with-xunit tests/test_paratext.py
+script: nosetests -s --failure-detail --with-xunit tests/test_paratext.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,15 @@ python:
   - "3.4"
 
 compiler:
-   - g++
-   - clang++
-#  - gcc-4.7
-#  - gcc-4.9
-#  - clang-3.7
-#  - clang-3.8
-#  - clang-nightly
-#  - gcc-5.3
-#  - gcc-nightly
+  - g++
+  - clang++
+  - gcc-4.7
+  - gcc-4.9
+  - clang-3.7
+  - clang-3.8
+  - clang-nightly
+  - gcc-5.3
+  - gcc-nightly
 
 before_install:
   - echo "before_install"
@@ -25,7 +25,7 @@ before_install:
   - python -V
   - which g++
   - g++ --version
-  - ls $(dirname $(which g++))/g++*
+  - export ""
   # g++4.8.1
   - if [ "$CXX" == "g++" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
   # clang 3.4
@@ -34,10 +34,11 @@ before_install:
 
 # command to install dependencies
 install:
+  - export CXX=g++
   # g++4.8.1
   - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
-
+  - ls $(dirname $(which g++))/g++*
   # clang 3.4
   - if [ "$CXX" == "clang++" ]; then sudo apt-get install --allow-unauthenticated -qq clang-3.4; fi
   - if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.4"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
+  - "3.5"
 
-compiler:
-  - g++
-  - clang++
-  - gcc-4.7
-  - gcc-4.9
-  - clang-3.7
-  - clang-3.8
-  - clang-nightly
-  - gcc-5.3
-  - gcc-nightly
+#compiler:
+#  - g++
+#  - clang++
+#  - gcc-4.7
+#  - gcc-4.9
+#  - clang-3.7
+#  - clang-3.8
+#  - clang-nightly
+#  - gcc-5.3
+#  - gcc-nightly
 
 before_install:
   - echo "before_install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,8 @@ install:
   - source activate test-environment
   - cd python
   - python setup.py build install
+  - cd ..
+  - pwd
 
 # command to run tests
-script: nosetests tests/test_paratext.py
+script: nosetests -xvs tests/test_paratext.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ install:
   # g++4.8.1
   - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
-  - ls $(dirname $(which g++))/g++*
   # clang 3.4
   - if [ "$CXX" == "clang++" ]; then sudo apt-get install --allow-unauthenticated -qq clang-3.4; fi
   - if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.4"; fi
+  - ls $(dirname $(which g++))/g++*
   - echo "install"
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - python -V
   - which g++
   - g++ --version
-  - export ""
+  - export CXX="g++"
   # g++4.8.1
   - if [ "$CXX" == "g++" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
   # clang 3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,15 @@ python:
   - "2.7"
   - "3.4"
 
+compiler:
+  - gcc-4.7
+  - gcc-4.9
+#  - clang-3.7
+#  - clang-3.8
+#  - clang-nightly
+#  - gcc-5.3
+#  - gcc-nightly
+
 before_install:
   - echo "before_install"
   - echo $VIRTUAL_ENV
@@ -15,15 +24,6 @@ before_install:
   - which g++
   - g++ --version
   - ls $(dirname $(which g++))/g++*
-
-compiler:
-  - gcc-4.7
-  - gcc-4.9
-#  - clang-3.7
-#  - clang-3.8
-#  - clang-nightly
-#  - gcc-5.3
-#  - gcc-nightly
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,4 +73,4 @@ before_script:
   - echo $PYTHONPATH
 
 # command to run tests
-script: nosetests -xvs tests/test_paratext.py
+script: nosetests -vs --with-xunit tests/test_paratext.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  # does not have headers provided, please ask https://launchpad.net/~pypy/+archive/ppa
+  # maintainers to fix their pypy-dev package.
+  - "pypy"
+
+before_install:
+  - echo "before_install"
+  - echo $VIRTUAL_ENV
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - df -h
+  - date
+  - pwd
+  - uname -a
+  - python -V
+
+# command to install dependencies
+install:
+  - echo "install"
+  - sudo apt-get update
+  # We do this conditionally because it saves us some downloading if the
+  # version is the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  # Replace dep1 dep2 ... with your dependencies
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION dep1 dep2 ...
+  - source activate test-environment
+  - python setup.py install
+
+# command to run tests
+script: nosetests tests/test_paratext.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
   # does not have headers provided, please ask https://launchpad.net/~pypy/+archive/ppa
   # maintainers to fix their pypy-dev package.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
   - pwd
   - uname -a
   - python -V
+  - g++ --version
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 python:
   - "2.7"
   - "3.4"
-  # does not have headers provided, please ask https://launchpad.net/~pypy/+archive/ppa
-  # maintainers to fix their pypy-dev package.
-  - "pypy"
 
 before_install:
   - echo "before_install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig=3.0.8
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig=3.0.8 pandas numpy
   - source activate test-environment
   - cd python
   - python setup.py build install

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,8 @@ install:
 before_script:
   - export PY_PREFIX=$(python -c "import sys; print(sys.prefix)")
   - echo $PY_PREFIX
-  - export PY_SP_DIR=$PY_PREFIX/lib/python$TRAVIS_PYTHON_VERSION/site-packages
-  - echo $PY_SP_DIR
+  - export PYTHONPATH=$PY_PREFIX/lib/python$TRAVIS_PYTHON_VERSION/site-packages:$PYTHONPATH
+  - echo $PYTHONPATH
 
 # command to run tests
 script: nosetests -xvs tests/test_paratext.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ python:
   - "3.4"
 
 compiler:
-  - gcc-4.7
-  - gcc-4.9
+   - g++
+   - clang++
+#  - gcc-4.7
+#  - gcc-4.9
 #  - clang-3.7
 #  - clang-3.8
 #  - clang-nightly
@@ -24,9 +26,21 @@ before_install:
   - which g++
   - g++ --version
   - ls $(dirname $(which g++))/g++*
+  # g++4.8.1
+  - if [ "$CXX" == "g++" ]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
+  # clang 3.4
+  - if [ "$CXX" == "clang++" ]; then sudo add-apt-repository -y ppa:h-rayflood/llvm; fi
+  - sudo apt-get update -qq
 
 # command to install dependencies
 install:
+  # g++4.8.1
+  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
+
+  # clang 3.4
+  - if [ "$CXX" == "clang++" ]; then sudo apt-get install --allow-unauthenticated -qq clang-3.4; fi
+  - if [ "$CXX" == "clang++" ]; then export CXX="clang++-3.4"; fi
   - echo "install"
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ install:
   - cd ..
   - pwd
 
-before-script:
+before_script:
   - export PY_PREFIX=$(python -c "import sys; print(sys.prefix)")
   - echo $PY_PREFIX
   - export PY_SP_DIR=$PY_PREFIX/lib/python$TRAVIS_PYTHON_VERSION/site-packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ before_install:
   - pwd
   - uname -a
   - python -V
+  - which g++
   - g++ --version
+  - ls $(dirname $(which g++))/g++*
 
 compiler:
   - gcc-4.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION dep1 dep2 ...
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig=3.0.8
   - source activate test-environment
   - python setup.py install
 

--- a/README.md
+++ b/README.md
@@ -224,16 +224,38 @@ Most CSV loading functions in ParaText have the following parameters:
     * `block_size`: The number of bytes to read at a time in each worker
     thread. The default is unlimited.
 
+Escape Characters
+-----------------
+
+ParaText supports backslash escape characters:
+
+    * `\t': tab
+
+    * `\n': newline
+
+    * `\r': carriage return
+
+    * `\v': vertical tab
+
+    * `\0': null terminator (0x00)
+
+    * `\b': backspace
+
+    * '\xnn': an 8-bit character represented with a 2 digit hexidecimal number.
+
+    * '\unnnn': a Unicode code point represented as 4-digit hexidecimal number.
+
+    * '\Unnnnnnnn': a Unicode code point represented as 8-digit hexiecimal number.
+
+
 Other Notes
 -----------
 
 ParaText is a work-in-progress. There are a few unimplemented features
 that may prevent it from working on all CSV files. We note them below.
 
-1. ParaText does not yet support escape characters or comments.
-
-2. There is no way to supply type hints (e.g. `uint64` or `float`) of a
+1. There is no way to supply type hints (e.g. `uint64` or `float`) of a
 column.  Only the interpretation of a column (numeric, categorical, or
 text) can be forced.
 
-3. DateTime support will be added in a future release.
+2. DateTime support will be added in a future release.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ the `load_csv_to_pandas` function.
 df = paratext.load_csv_to_pandas("hepatitis.csv")
 ```
 
-Its output looks something like this:
+The data frame looks something like this:
 
 ```
 In [1]: print df.head()
@@ -121,7 +121,7 @@ levels (`None` if not categorical).
       print key, repr(dict_frame[key][0:5]), levels.get(key, None)
 ```
 
-The output looks something like this:
+This gives the following output:
 
 ```
 PROTIME array([ nan,  nan,  nan,  80.,  nan], dtype=float32) None
@@ -247,6 +247,51 @@ ParaText supports backslash escape characters:
 
     * '\Unnnnnnnn': a Unicode code point represented as 8-digit hexiecimal number.
 
+Writing CSV
+-----------
+
+ParaText does yet support parallel CSV writing. However, it bundles a CSV
+writer that can be used to write DataFrames with arbitrary string and byte
+buffer data in a lossless fashion.
+
+If a character in a Python `string`, `unicode`, or `bytes`
+object could be treated as non-data when parsed (e.g. a doublequote or
+escape character), it is escaped. Moreover, any character that is outside
+the desired encoding is also escaped. This enables, for example,
+the lossless writing of non-UTF-8 to a UTF-8 file.
+
+For example, to restrict the encoding to 7-bit printable ASCII, pass
+`out_encoding='printable_ascii'`
+
+```
+   import paratext.serial
+   df = pandas.DataFrame({"X": [b"\xff\\\n \" oh my!"]})
+   paratext.serial.save_frame("lossless.csv", df, allow_quoted_newlines=True, out_encoding='printable_ascii', dos=False)
+```
+
+This results in a file:
+
+```
+"X"
+"\xff\\
+ \" oh my!"
+```
+
+Instead, pass `out_encoding='utf-8'` to ``save_frame``.
+
+```
+   import paratext.serial
+   df = pandas.DataFrame({"X": [b"\xff\\\n \" oh my!"],"Y": ["\U0001F600"]})
+   paratext.serial.save_frame("lossless2.csv", df, allow_quoted_newlines=True, out_encoding='utf-8', dos=False)
+```
+
+Now, the file only escapes cells in the DataFrame with
+non-UTF8 data. All other UTF8 characters are preserved.
+```
+"X","Y"
+"\xff\\
+ \" oh my!","<U+1F600>"
+```
 
 Other Notes
 -----------
@@ -258,4 +303,4 @@ that may prevent it from working on all CSV files. We note them below.
 column.  Only the interpretation of a column (numeric, categorical, or
 text) can be forced.
 
-2. DateTime support will be added in a future release.
+2. DateTime will be supported in a future release.

--- a/python/paratext/core.py
+++ b/python/paratext/core.py
@@ -84,6 +84,12 @@ _csv_load_params_doc = """
     num_names : sequence
         A list of column names that should be treated as numeric
         regardless of its inferred type.
+
+    in_encoding : str
+        The encoding of the data read from the file. (default=None)
+
+    out_encoding : str
+        The encoding of the strings returned.
 """
 
 def _get_params(num_threads=0, allow_quoted_newlines=False, block_size=32768, number_only=False, no_header=False, max_level_name_length=None, max_levels=None):
@@ -113,7 +119,7 @@ def _make_posix_filename(fn_or_uri):
      return result
 
 @_docstring_parameter(_csv_load_params_doc)
-def internal_create_csv_loader(filename, num_threads=0, allow_quoted_newlines=False, block_size=32768, number_only=False, no_header=False, max_level_name_length=None, max_levels=None, cat_names=None, text_names=None, num_names=None):
+def internal_create_csv_loader(filename, num_threads=0, allow_quoted_newlines=False, block_size=32768, number_only=False, no_header=False, max_level_name_length=None, max_levels=None, cat_names=None, text_names=None, num_names=None, in_encoding=None, out_encoding=None):
     """
     Creates a ParaText internal C++ CSV reader object and reads the CSV
     file in parallel. This function ordinarily should not be called directly.
@@ -158,6 +164,14 @@ def internal_create_csv_loader(filename, num_threads=0, allow_quoted_newlines=Fa
         for name in text_names:
             name = encoder(name)
             loader.force_semantics(name, pti.TEXT)
+    if in_encoding is not None and in_encoding not in ("utf-8", "unknown"):
+        raise ValueError("invalid encoding: " % in_encoding)
+    if out_encoding is not None and out_encoding not in ("utf-8", "unknown"):
+        raise ValueError("invalid encoding: " % out_encoding)
+    if in_encoding == "utf-8":
+        loader.set_in_encoding(pti.UNICODE_UTF8)
+    if out_encoding == "utf-8":
+        loader.set_out_encoding(pti.UNICODE_UTF8)
     loader.load(_make_posix_filename(filename), params)
     return loader
 

--- a/python/paratext/core.py
+++ b/python/paratext/core.py
@@ -89,10 +89,16 @@ _csv_load_params_doc = """
         The encoding of the data read from the file. (default=None)
 
     out_encoding : str
-        The encoding of the strings returned.
+        The encoding of the strings returned. If set to 'utf-8', the
+        parsed data will be converted to UTF-8 unicode object (Python 2.7)
+        or str object (Python 3+). Otherwise a str object (Python 2.7)
+        or bytes object (Python 3+) is returned. (default=None)
+
+    convert_null_to_space : bool
+        Whether to convert null terminator characters to spaces. (default=False)
 """
 
-def _get_params(num_threads=0, allow_quoted_newlines=False, block_size=32768, number_only=False, no_header=False, max_level_name_length=None, max_levels=None):
+def _get_params(num_threads=0, allow_quoted_newlines=False, block_size=32768, number_only=False, no_header=False, max_level_name_length=None, max_levels=None, convert_null_to_space=True):
     params = pti.ParseParams()
     params.allow_quoted_newlines = allow_quoted_newlines
     if num_threads > 0:
@@ -101,6 +107,7 @@ def _get_params(num_threads=0, allow_quoted_newlines=False, block_size=32768, nu
         params.num_threads = int(max(pti.get_num_cores(), 4))
     params.number_only = number_only
     params.no_header = no_header
+    params.convert_null_to_space = convert_null_to_space
     if max_levels is not None:
         params.max_levels = max_levels;
     if max_level_name_length is not None:
@@ -119,7 +126,7 @@ def _make_posix_filename(fn_or_uri):
      return result
 
 @_docstring_parameter(_csv_load_params_doc)
-def internal_create_csv_loader(filename, num_threads=0, allow_quoted_newlines=False, block_size=32768, number_only=False, no_header=False, max_level_name_length=None, max_levels=None, cat_names=None, text_names=None, num_names=None, in_encoding=None, out_encoding=None):
+def internal_create_csv_loader(filename, num_threads=0, allow_quoted_newlines=False, block_size=32768, number_only=False, no_header=False, max_level_name_length=None, max_levels=None, cat_names=None, text_names=None, num_names=None, in_encoding=None, out_encoding=None, convert_null_to_space=True):
     """
     Creates a ParaText internal C++ CSV reader object and reads the CSV
     file in parallel. This function ordinarily should not be called directly.
@@ -144,6 +151,7 @@ def internal_create_csv_loader(filename, num_threads=0, allow_quoted_newlines=Fa
         params.num_threads = int(max(pti.get_num_cores(), 4))
     params.number_only = number_only
     params.no_header = no_header
+    params.convert_null_to_space = convert_null_to_space
     if max_levels is not None:
         params.max_levels = max_levels;
     if max_level_name_length is not None:

--- a/python/paratext/serial.py
+++ b/python/paratext/serial.py
@@ -97,13 +97,13 @@ def save_frame(filename, frame, allow_quoted_newlines=True, out_encoding='arbitr
     {0}
     """
     f = open(filename, 'wb')
-    write_frame(f, frame, allow_quoted_newlines, out_encoding=out_encoding, dos=dos)
+    write_frame(f, frame, allow_quoted_newlines=allow_quoted_newlines, out_encoding=out_encoding, dos=dos)
     f.close()
 
 @_docstring_parameter(_save_frame_params)
 def write_frame(stream, frame, allow_quoted_newlines=True, out_encoding='arbitrary', dos=False):
     """
-    Saves a dictframe/DataFrame of sequences of the same size to a byte stream (binary required.
+    Saves a dictframe/DataFrame of sequences of the same size to a byte stream (binary mode).
 
     Parameters
     ----------

--- a/python/paratext/serial.py
+++ b/python/paratext/serial.py
@@ -1,0 +1,191 @@
+"""
+Single-threaded utilities
+"""
+
+#   Licensed to the Apache Software Foundation (ASF) under one
+#   or more contributor license agreements.  See the NOTICE file
+#   distributed with this work for additional information
+#   regarding copyright ownership.  The ASF licenses this file
+#   to you under the Apache License, Version 2.0 (the
+#   "License"); you may not use this file except in compliance
+#   with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0 
+#
+#   Unless required by applicable law or agreed to in writing,
+#   software distributed under the License is distributed on an
+#   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#   KIND, either express or implied.  See the License for the
+#   specific language governing permissions and limitations
+#   under the License.
+#
+#   Copyright (C) Wise.io, Inc. 2016.
+
+
+#
+#   Coder: Damian Eads
+#
+
+import paratext_internal as pti
+
+import os
+import six
+from six.moves import range
+from six.moves.urllib_parse import urlparse
+
+import random
+import numpy as np
+import string
+
+import numpy as np
+import unittest
+import collections
+import pandas
+import paratext_internal
+import os
+import random
+import sys
+
+if sys.version_info>=(3,0):
+    def _repr_bytes(o):
+        return bytes(repr(o), 'utf-8')
+else:
+    def _repr_bytes(o):
+        return repr(o)
+
+def as_quoted_string(s, do_not_escape_newlines=False):
+    return paratext_internal.as_quoted_string(s, do_not_escape_newlines)
+
+
+def _docstring_parameter(*sub):
+     def dec(obj):
+         obj.__doc__ = obj.__doc__.format(*sub)
+         return obj
+     return dec
+
+_save_frame_params = """
+    frame : DataFrame, mapping, dict
+         This object must be DataFrame-like (ie implement .keys() and __getattr__).
+
+    allow_quoted_newlines : bool
+         Whether to allow newlines to be unescaped in a quoted string. If False, all newline
+         are encountered are escaped.
+
+    out_encoding : bool
+         The encoding to use. Valid options include:
+            - `utf-8`: UTF-8 data
+            - `arbitrary`: arbitrary bytes (values 0x00-0xFF)
+            - `printable_ascii`: values 0x20-0xFF. 0x0A is included if `allow_quoted_newlines`=True
+            - `ascii`: values 0x00-0x7F
+         If any values are outside of this range, they are backslash-escaped.
+
+    dos : bool
+         Whether to add a carriage return before a newline (Windows and DOS compatability).
+"""
+
+
+@_docstring_parameter(_save_frame_params)
+def save_frame(filename, frame, allow_quoted_newlines=True, out_encoding='arbitrary', dos=False):
+    """
+    Saves a dictframe/DataFrame of sequences of the same size to a CSV file.
+
+    Parameters
+    ----------
+    filename : str, unicode
+         The name of the filename to write.
+
+    {0}
+    """
+    f = open(filename, 'wb')
+    write_frame(f, frame, allow_quoted_newlines, out_encoding=out_encoding, dos=dos)
+    f.close()
+
+@_docstring_parameter(_save_frame_params)
+def write_frame(stream, frame, allow_quoted_newlines=True, out_encoding='arbitrary', dos=False):
+    """
+    Saves a dictframe/DataFrame of sequences of the same size to a byte stream (binary required.
+
+    Parameters
+    ----------
+    filename : str, unicode
+         The name of the filename to write.
+
+    {0}
+    """
+
+    # In case .keys() is non-deterministic
+    keys = list(frame.keys())
+    cols = []
+
+    psafe=paratext_internal.SafeStringOutput()
+    psafe.escape_nonascii(True)
+    psafe.escape_nonprintables(True)
+    safe=paratext_internal.SafeStringOutput()
+    safe.escape_special(True)
+    if out_encoding == 'utf-8':
+        safe.escape_nonutf8(True)
+    elif out_encoding == 'ascii':
+        safe.escape_nonascii(True)
+    elif out_encoding == 'printable_ascii':
+        safe.escape_nonascii(True)
+        safe.escape_nonprintables(True)
+    if not allow_quoted_newlines:
+        safe.escape_newlines(True)
+        psafe.escape_newlines(True)
+    safe.double_quote_output(True)
+    psafe.double_quote_output(True)
+    for col in range(len(keys)):
+        if col > 0:
+            stream.write(b",")
+            stream.flush()
+        key = keys[col]
+        if out_encoding == 'utf-8':
+            stream.flush()
+            if isinstance(key, bytes):
+                skey = psafe.to_raw_string(key)
+            else:
+                skey = safe.to_raw_string(key)
+            stream.write(skey)
+        else:
+            stream.flush()
+            if isinstance(key, bytes):
+                skey = psafe.to_raw_string(key)
+            else:
+                skey = safe.to_raw_string(key)
+            stream.write(skey)
+        if isinstance(frame[key], pandas.Series):
+            cols.append(frame[key].values)
+        else:
+            cols.append(np.asarray(frame[key]))
+    if dos:
+        stream.write(b"\r\n")
+    else:
+        stream.write(b"\n")
+    if hasattr(frame, "shape"):
+        num_rows = frame.shape[0]
+    elif len(keys) == 0:
+        num_rows = 0
+    else:
+        num_rows = len(frame[keys[0]])
+    for row in range(num_rows):
+        for col in range(len(cols)):
+            if col > 0:
+                stream.write(b',')
+            val = cols[col][row]
+            if np.issubdtype(type(val), np.string_) or np.issubdtype(type(val), np.unicode_) or isinstance(val, six.string_types):
+                if out_encoding == 'utf-8':
+                    #sval = safe.to_utf8_string(val)
+                    if isinstance(val, bytes):
+                        sval = psafe.to_raw_string(val)
+                    else:
+                        sval = safe.to_raw_string(val)
+                    stream.write(sval)
+                else:
+                    sval = safe.to_raw_string(val)
+                    stream.write(sval)
+            else:
+                stream.write(bytes(_repr_bytes(val)))
+        if dos:
+            stream.write(b"\r\n")
+        else:
+            stream.write(b"\n")

--- a/python/paratext/testing.py
+++ b/python/paratext/testing.py
@@ -34,7 +34,7 @@ import six
 
 if sys.version_info>=(3,0):
     def _repr_bytes(o):
-        return repr(o, 'utf-8')
+        return bytes(repr(o), 'utf-8')
 else:
     def _repr_bytes(o):
         return repr(o)

--- a/python/paratext/testing.py
+++ b/python/paratext/testing.py
@@ -78,6 +78,32 @@ def generate_hell_frame(num_rows, num_columns, include_null=False, fmt='arbitrar
     return pandas.DataFrame(frame)
 
 def save_frame(filename, frame, allow_quoted_newlines=True, out_format='arbitrary', dos=False):
+    """
+    Saves a dictframe/DataFrame of sequences of the same size to a CSV file.
+
+    Parameters
+    ----------
+    filename : str, unicode
+         The name of the filename to write.
+
+    frame : DataFrame, mapping, dict
+         This object must be DataFrame-like (ie implement .keys() and __getattr__).
+
+    allow_quoted_newlines : bool
+         Whether to allow newlines to be unescaped in a quoted string. If True, if newlines
+         are encountered, they will be escaped with two ASCII characters.
+
+    out_encoding : bool
+         The encoding to use. Valid options include:
+            - `utf-8`: UTF-8 data
+            - `arbitrary`: arbitrary bytes (values 0x00-0xFF)
+            - `printable_ascii`: values 0x20-0xFF. 0x0A is included if `allow_quoted_newlines`=True
+            - `ascii`: values 0x00-0x7F
+         If any values are outside of this range, they are backslash-escaped.
+
+    dos : bool
+         Whether to add a carriage return before a newline as done in Windows and DOS.
+    """
     f = open(filename, 'wb')
     write_frame(f, frame, allow_quoted_newlines, out_format=out_format, dos=dos)
     f.close()
@@ -162,6 +188,14 @@ def write_frame(stream, frame, allow_quoted_newlines=True, out_format='arbitrary
 
 @contextmanager
 def generate_tempfile(filedata):
+    """
+    A context manager that generates a temporary file object that will be deleted
+    when the context goes out of scope. The mode of the file is "wb".
+
+    Parameters
+    ----------
+    filedata : The data of the file to write as a bytes object.
+    """
     f = NamedTemporaryFile(delete=False, mode="wb", prefix="paratext-tests")
     f.write(filedata)
     name = f.name
@@ -171,6 +205,10 @@ def generate_tempfile(filedata):
 
 @contextmanager
 def generate_tempfilename():
+    """
+    A context manager that generates a temporary filename that will be deleted
+    when the context goes out of scope.
+    """
     f = NamedTemporaryFile(delete=False, prefix="paratext-tests")
     name = f.name
     f.close()

--- a/python/paratext/testing.py
+++ b/python/paratext/testing.py
@@ -102,8 +102,8 @@ def generate_tempfilename():
 def assert_seq_almost_equal(left, right):
     left = np.asarray(left)
     right = np.asarray(right)
-    left_is_string = np.issubdtype(left.dtype, np.str_) or np.issubdtype(left.dtype, np.unicode_) or np.issubdtype(left.dtype, np.object_)
-    right_is_string = np.issubdtype(right.dtype, np.str_) or np.issubdtype(right.dtype, np.unicode_) or np.issubdtype(right.dtype, np.object_)
+    left_is_string = np.issubdtype(left.dtype, np.str_) or np.issubdtype(left.dtype, np.unicode_) or left.dtype == np.object_
+    right_is_string = np.issubdtype(right.dtype, np.str_) or np.issubdtype(right.dtype, np.unicode_) or right.dtype == np.object_
     if np.issubdtype(left.dtype, np.integer) and np.issubdtype(right.dtype, np.integer):
         if not (left.shape == right.shape):
             raise AssertionError("integer sequences have different sizes: %s vs %s" % (str(left.shape), str(right.shape)))
@@ -113,10 +113,12 @@ def assert_seq_almost_equal(left, right):
     elif np.issubdtype(left.dtype, np.floating) and np.issubdtype(right.dtype, np.floating):
         np.testing.assert_almost_equal(left, right)
     elif left_is_string and not right_is_string:
-        raise AssertionError("sequences differ by type: left is string and right is %s" % (str(right.dtype)))
+        if len(left) > 0 and len(right) > 0:
+            raise AssertionError("sequences differ by dtype: left is string and right is %s" % (str(right.dtype)))
     elif not left_is_string and right_is_string:
-        raise AssertionError("sequences differ by type: left is %s and right is string" % (str(right.dtype)))
-    elif left_is_string or right_is_string:
+        if len(left) > 0 and len(right) > 0:
+            raise AssertionError("sequences differ by dtype: left is %s and right is string" % (str(left.dtype)))
+    elif left_is_string and right_is_string:
         q = np.zeros((len(left)))
         for i in range(len(q)):
             q[i] = not paratext_internal.are_strings_equal(left[i], right[i])

--- a/python/paratext/testing.py
+++ b/python/paratext/testing.py
@@ -25,11 +25,19 @@ import pandas
 import paratext_internal
 import os
 import random
+import sys
 
 from tempfile import NamedTemporaryFile
 from contextlib import contextmanager
 from six.moves import range
 import six
+
+if sys.version_info>=(3,0):
+    def _repr_bytes(o):
+        return repr(o, 'utf-8')
+else:
+    def _repr_bytes(o):
+        return repr(o)
 
 def as_quoted_string(s, do_not_escape_newlines=False):
     return paratext_internal.as_quoted_string(s, do_not_escape_newlines)
@@ -143,7 +151,7 @@ def write_frame(stream, frame, allow_quoted_newlines=True, out_format='arbitrary
                     sval = safe.to_raw_string(val)
                     stream.write(sval)
             else:
-                stream.write(bytes(repr(val), 'utf-8'))
+                stream.write(bytes(_repr_bytes(val)))
         stream.write(b"\n")
 
 @contextmanager

--- a/python/paratext/testing.py
+++ b/python/paratext/testing.py
@@ -1,0 +1,122 @@
+import numpy as np
+import pandas.util.testing
+import unittest
+import collections
+import pandas
+import paratext_internal
+import os
+
+from tempfile import NamedTemporaryFile
+from contextlib import contextmanager
+from six.moves import range
+
+def as_quoted_string(s, do_not_escape_newlines=False):
+    return paratext_internal.as_quoted_string(s, do_not_escape_newlines)
+
+def generate_hell_frame(num_rows, num_columns):
+    frame = collections.OrderedDict()
+    for column in range(num_columns):
+        key = "col%d" % (column,)
+        data = []
+        for row in range(num_rows):
+            length = np.random.randint(50,1000)
+            cell = paratext_internal.get_random_string(length, 1, 127)
+            data.append(cell)
+        frame[key] = data
+    return pandas.DataFrame(frame)
+
+def save_frame(filename, frame):
+    f = open(filename, 'w')
+    write_frame(f, frame)
+    f.close()
+
+def write_frame(stream, frame):
+    # In case .keys() is non-deterministic
+    keys = list(frame.keys())
+    cols = []
+    for col in range(len(keys)):
+        if col > 0:
+            stream.write(",")
+        key = keys[col]
+        stream.write(as_quoted_string(key, True))
+        cols.append(frame[key].values)
+    stream.write("\n")
+    for row in range(frame.shape[0]):
+        for col in range(len(cols)):
+            if col > 0:
+                stream.write(',')
+            translated = as_quoted_string(cols[col][row], True)
+            stream.write(translated)
+        stream.write("\n")
+
+@contextmanager
+def generate_tempfile(filedata):
+    f = NamedTemporaryFile(delete=False, prefix="paratext-tests")
+    f.write(filedata.encode("utf-8"))
+    name = f.name
+    f.close()
+    yield f.name
+    os.remove(name)
+
+@contextmanager
+def generate_tempfilename():
+    f = NamedTemporaryFile(delete=False, prefix="paratext-tests")
+    name = f.name
+    f.close()
+    yield f.name
+    os.remove(name)
+
+def assert_seq_almost_equal(left, right):
+    left = np.asarray(left)
+    right = np.asarray(right)
+    if np.issubdtype(left.dtype, np.integer) and np.issubdtype(right.dtype, np.integer):
+        print(left, right, left == right)
+        if not (left.shape == right.shape):
+            raise AssertionError("integer sequences have different sizes: %s vs %s" % (str(left.shape), str(right.shape)))
+        if not (left == right).all():
+            m = (left != right).mean() * 100.
+            raise AssertionError("integer sequences mismatch: %5.5f%%" % (m,))
+    elif np.issubdtype(left.dtype, np.floating) and np.issubdtype(right.dtype, np.floating):
+        np.testing.assert_almost_equal(left, right)
+    elif np.issubdtype(left.dtype, np.str_) or np.issubdtype(left.dtype, np.unicode_) or np.issubdtype(right.dtype, np.str_) or np.issubdtype(right.dtype, np.unicode_) or np.issubdtype(left.dtype, np.object_) or np.issubdtype(right.dtype, np.object_):
+        q = np.zeros((len(left)))
+        for i in range(len(q)):
+            q[i] = left[i] != right[i]
+        m = q.mean() * 100.
+        if q.any():
+            raise AssertionError("object sequences mismatch: %5.5f%%, rows: %s" % (m, str(np.where(q)[0].tolist())))
+    else:
+        if np.issubdtype(left.dtype, np.floating):
+            left_float = left
+        else:
+            left_float = np.asarray(left, dtype=np.float_)
+        if np.issubdtype(right.dtype, np.floating):
+            right_float = right
+        else:
+            right_float = np.asarray(right, dtype=np.float_)
+        pandas.util.testing.assert_almost_equal(left_float, right_float)
+
+def assert_dictframe_almost_equal(left, right):
+    """
+    Compares two dictframes for equivalent. A dict-frame is simply
+    an object that obeys the Python mapping protocol. Each (key, value)
+    represents a column keyed/indexed by `key` where `value` is
+    a NumPy array, a Python sequence, or Python iterable.
+    """
+    left_keys = set(left.keys())
+    right_keys = set(right.keys())
+    left_missing = right_keys - left_keys
+    right_missing = left_keys - right_keys
+    together = left_keys.intersection(right_keys)
+    msg = ""
+    for key in left_missing:
+        msg += "%s: missing on left\n" % key
+    for key in right_missing:
+        msg += "%s: missing on right\n" % key
+    for key in together:
+        try:
+            assert_seq_almost_equal(left[key], right[key])
+        except AssertionError as e:
+            msg += "\n Column %s: %s" % (key, e.args[0])
+    if len(msg) > 0:
+        raise AssertionError(msg)

--- a/python/paratext/testing.py
+++ b/python/paratext/testing.py
@@ -102,15 +102,21 @@ def generate_tempfilename():
 def assert_seq_almost_equal(left, right):
     left = np.asarray(left)
     right = np.asarray(right)
+    left_is_string = np.issubdtype(left.dtype, np.str_) or np.issubdtype(left.dtype, np.unicode_) or np.issubdtype(left.dtype, np.object_)
+    right_is_string = np.issubdtype(right.dtype, np.str_) or np.issubdtype(right.dtype, np.unicode_) or np.issubdtype(right.dtype, np.object_)
     if np.issubdtype(left.dtype, np.integer) and np.issubdtype(right.dtype, np.integer):
         if not (left.shape == right.shape):
             raise AssertionError("integer sequences have different sizes: %s vs %s" % (str(left.shape), str(right.shape)))
         if not (left == right).all():
             m = (left != right).mean() * 100.
-            raise AssertionError("integer sequences mismatch: %5.5f%%" % (m,))
+            raise AssertionError("integer sequences mismatch: %5.5f%% left=%s right=%s" % ((m, str(left[0:20]), str(right[0:20]))))
     elif np.issubdtype(left.dtype, np.floating) and np.issubdtype(right.dtype, np.floating):
         np.testing.assert_almost_equal(left, right)
-    elif np.issubdtype(left.dtype, np.str_) or np.issubdtype(left.dtype, np.unicode_) or np.issubdtype(right.dtype, np.str_) or np.issubdtype(right.dtype, np.unicode_) or np.issubdtype(left.dtype, np.object_) or np.issubdtype(right.dtype, np.object_):
+    elif left_is_string and not right_is_string:
+        raise AssertionError("sequences differ by type: left is string and right is %s" % (str(right.dtype)))
+    elif not left_is_string and right_is_string:
+        raise AssertionError("sequences differ by type: left is %s and right is string" % (str(right.dtype)))
+    elif left_is_string or right_is_string:
         q = np.zeros((len(left)))
         for i in range(len(q)):
             q[i] = not paratext_internal.are_strings_equal(left[i], right[i])

--- a/python/paratext/testing.py
+++ b/python/paratext/testing.py
@@ -1,3 +1,22 @@
+#   Licensed to the Apache Software Foundation (ASF) under one
+#   or more contributor license agreements.  See the NOTICE file
+#   distributed with this work for additional information
+#   regarding copyright ownership.  The ASF licenses this file
+#   to you under the Apache License, Version 2.0 (the
+#   "License"); you may not use this file except in compliance
+#   with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing,
+#   software distributed under the License is distributed on an
+#   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#   KIND, either express or implied.  See the License for the
+#   specific language governing permissions and limitations
+#   under the License.
+#
+#   Copyright (C) Wise.io, Inc. 2016.
+
 import numpy as np
 import pandas.util.testing
 import unittest
@@ -5,49 +24,127 @@ import collections
 import pandas
 import paratext_internal
 import os
+import random
 
 from tempfile import NamedTemporaryFile
 from contextlib import contextmanager
 from six.moves import range
+import six
 
 def as_quoted_string(s, do_not_escape_newlines=False):
     return paratext_internal.as_quoted_string(s, do_not_escape_newlines)
 
-def generate_hell_frame(num_rows, num_columns):
+def generate_hell_frame(num_rows, num_columns, include_null=False, fmt='arbitrary'):
+    if include_null:
+        min_byte = 0
+    else:
+        min_byte = 1
     frame = collections.OrderedDict()
+    seed = 0
+    keys = []
+    colfmts = {}
     for column in range(num_columns):
         key = "col%d" % (column,)
+        keys.append(key)
+        if fmt == 'mixed':
+            colfmts[key] = random.choice(["ascii","arbitrary","printable_ascii","utf-8"])
+        else:
+            colfmts[key] = fmt
+    for key in keys:
         data = []
+        colfmt = colfmts[key]
         for row in range(num_rows):
             length = np.random.randint(50,1000)
-            cell = paratext_internal.get_random_string(length, 1, 127)
+            if colfmt == 'arbitrary':
+                cell = paratext_internal.get_random_string(length, seed, min_byte, 255)
+            elif colfmt == 'ascii':
+                cell = paratext_internal.get_random_string(length, seed, min_byte, 127)
+            elif colfmt == 'printable_ascii':
+                cell = paratext_internal.get_random_string(length, seed, 32, 126)
+            elif colfmt == 'utf-8' or fmt == 'utf-8':
+                cell = paratext_internal.get_random_string_utf8(length, seed, include_null)
+            else:
+                raise ValueError("unknown format: " + fmt)
             data.append(cell)
         frame[key] = data
     return pandas.DataFrame(frame)
 
-def save_frame(filename, frame):
-    f = open(filename, 'w')
-    write_frame(f, frame)
+def save_frame(filename, frame, allow_quoted_newlines=True, out_format='arbitrary'):
+    f = open(filename, 'wb')
+    write_frame(f, frame, allow_quoted_newlines, out_format=out_format)
     f.close()
 
-def write_frame(stream, frame):
+def write_frame(stream, frame, allow_quoted_newlines=True, out_format='arbitrary'):
     # In case .keys() is non-deterministic
     keys = list(frame.keys())
     cols = []
+
+    psafe=paratext_internal.SafeStringOutput()
+    psafe.escape_nonascii(True)
+    psafe.escape_nonprintables(True)
+    safe=paratext_internal.SafeStringOutput()
+    safe.escape_special(True)
+    if out_format == 'utf-8':
+        safe.escape_nonutf8(True)
+    elif out_format == 'ascii':
+        safe.escape_nonascii(True)
+    elif out_format == 'printable_ascii':
+        safe.escape_nonascii(True)
+        safe.escape_nonprintables(True)
+    if not allow_quoted_newlines:
+        safe.escape_newlines(True)
+        psafe.escape_newlines(True)
+    safe.double_quote_output(True)
+    psafe.double_quote_output(True)
     for col in range(len(keys)):
         if col > 0:
-            stream.write(",")
+            stream.write(b",")
+            stream.flush()
         key = keys[col]
-        stream.write(as_quoted_string(key, True))
-        cols.append(frame[key].values)
-    stream.write("\n")
-    for row in range(frame.shape[0]):
+        if out_format == 'utf-8':
+            stream.flush()
+            if isinstance(key, bytes):
+                skey = psafe.to_raw_string(key)
+            else:
+                skey = safe.to_raw_string(key)
+            stream.write(skey)
+        else:
+            stream.flush()
+            if isinstance(key, bytes):
+                skey = psafe.to_raw_string(key)
+            else:
+                skey = safe.to_raw_string(key)
+            stream.write(skey)
+        if isinstance(frame[key], pandas.Series):
+            cols.append(frame[key].values)
+        else:
+            cols.append(np.asarray(frame[key]))
+    stream.write(b"\n")
+    if hasattr(frame, "shape"):
+        num_rows = frame.shape[0]
+    elif len(keys) == 0:
+        num_rows = 0
+    else:
+        num_rows = len(frame[keys[0]])
+    for row in range(num_rows):
         for col in range(len(cols)):
             if col > 0:
-                stream.write(',')
-            translated = as_quoted_string(cols[col][row], True)
-            stream.write(translated)
-        stream.write("\n")
+                stream.write(b',')
+            val = cols[col][row]
+            if np.issubdtype(type(val), np.string_) or np.issubdtype(type(val), np.unicode_) or isinstance(val, six.string_types):
+                if out_format == 'utf-8':
+                    #sval = safe.to_utf8_string(val)
+                    if isinstance(val, bytes):
+                        sval = psafe.to_raw_string(val)
+                    else:
+                        sval = safe.to_raw_string(val)
+                    stream.write(sval)
+                else:
+                    sval = safe.to_raw_string(val)
+                    stream.write(sval)
+            else:
+                stream.write(bytes(repr(val), 'utf-8'))
+        stream.write(b"\n")
 
 @contextmanager
 def generate_tempfile(filedata):
@@ -70,7 +167,6 @@ def assert_seq_almost_equal(left, right):
     left = np.asarray(left)
     right = np.asarray(right)
     if np.issubdtype(left.dtype, np.integer) and np.issubdtype(right.dtype, np.integer):
-        print(left, right, left == right)
         if not (left.shape == right.shape):
             raise AssertionError("integer sequences have different sizes: %s vs %s" % (str(left.shape), str(right.shape)))
         if not (left == right).all():
@@ -81,7 +177,7 @@ def assert_seq_almost_equal(left, right):
     elif np.issubdtype(left.dtype, np.str_) or np.issubdtype(left.dtype, np.unicode_) or np.issubdtype(right.dtype, np.str_) or np.issubdtype(right.dtype, np.unicode_) or np.issubdtype(left.dtype, np.object_) or np.issubdtype(right.dtype, np.object_):
         q = np.zeros((len(left)))
         for i in range(len(q)):
-            q[i] = left[i] != right[i]
+            q[i] = not paratext_internal.are_strings_equal(left[i], right[i])
         m = q.mean() * 100.
         if q.any():
             raise AssertionError("object sequences mismatch: %5.5f%%, rows: %s" % (m, str(np.where(q)[0].tolist())))
@@ -96,7 +192,7 @@ def assert_seq_almost_equal(left, right):
             right_float = np.asarray(right, dtype=np.float_)
         pandas.util.testing.assert_almost_equal(left_float, right_float)
 
-def assert_dictframe_almost_equal(left, right):
+def assert_dictframe_almost_equal(left, right, err_msg=""):
     """
     Compares two dictframes for equivalent. A dict-frame is simply
     an object that obeys the Python mapping protocol. Each (key, value)
@@ -108,7 +204,7 @@ def assert_dictframe_almost_equal(left, right):
     left_missing = right_keys - left_keys
     right_missing = left_keys - right_keys
     together = left_keys.intersection(right_keys)
-    msg = ""
+    msg = err_msg
     for key in left_missing:
         msg += "%s: missing on left\n" % key
     for key in right_missing:
@@ -120,3 +216,43 @@ def assert_dictframe_almost_equal(left, right):
             msg += "\n Column %s: %s" % (key, e.args[0])
     if len(msg) > 0:
         raise AssertionError(msg)
+
+def generate_mixed_frame(num_rows, num_floats, num_cats, num_ints):
+    fid = open("/usr/share/dict/words")
+    words=[line.strip() for line in fid.readlines()]
+    num_cols = num_floats + num_cats + num_ints
+    perm = np.random.permutation(num_cols)
+    num_catints = num_cats + num_ints
+    float_ids = perm[num_catints:]
+    int_ids = perm[num_cats:num_catints]
+    cat_ids = perm[0:num_cats]
+    cat_ids = ["col" + str(id) for id in cat_ids]
+    int_ids = ["col" + str(id) for id in int_ids]
+    float_ids = ["col" + str(id) for id in float_ids]
+    d = {}
+    dtypes = {}
+    for col in cat_ids:
+        X = np.zeros((num_rows,), dtype=np.object);
+        for row in range(0, num_rows):
+            num_newlines = np.random.randint(3,7)
+            num_commas = np.random.randint(3,7)
+            X[row] = ""
+            tricky_delims = np.asarray(["\n"] * num_newlines + [","] * num_commas)
+            np.random.shuffle(tricky_delims)
+            for delim in tricky_delims:
+                X[row] += ' '.join(random.sample(words, 5))
+                X[row] += delim
+                X[row] += ' '.join(random.sample(words, 5))
+        d[col] = X
+        dtypes[col] = np.object
+    for col in float_ids:
+        d[col] = np.asarray(np.random.randn(num_rows), dtype=np.float32)
+        dtypes[col] = np.float32
+    min_int = [0,   -2**7, 0   , -2**15,     0, -2**31,     0, -2**62]
+    max_int = [2**8, 2**7, 2**16,  2**15, 2**32,  2**31, 2**62, 2**62]
+    dtypes_int = [np.uint8, np.int8, np.uint16, np.int16, np.uint32, np.int32, np.uint64, np.int64]
+    for col in int_ids:
+        j = np.random.randint(0, len(min_int))
+        d[col] = np.asarray(np.random.randint(min_int[j], max_int[j], num_rows), dtype=dtypes_int[j])
+        dtypes[col] = dtypes_int[j]
+    return d, dtypes

--- a/python/setup.py
+++ b/python/setup.py
@@ -45,7 +45,6 @@ init_py.write("""
 __all__ = ['paratext']
 
 from paratext.core import *
-from paratext.helpers import *
 
 import paratext_internal
 import warnings

--- a/src/csv/colbased_loader.hpp
+++ b/src/csv/colbased_loader.hpp
@@ -234,7 +234,7 @@ namespace ParaText {
       Returns the number of columns parsed by this loader.
      */
     size_t     get_num_columns() const {
-      return column_chunks_.size() == 0 ? 0 : column_chunks_[0].size();
+      return column_chunks_.size() == 0 ? header_parser_.get_num_columns() : column_chunks_[0].size();
     }
 
     /*
@@ -584,6 +584,20 @@ namespace ParaText {
           thread_exception = workers[i]->get_exception();
         }
       }
+#if 0
+      if (threads.size() == 0) {
+        column_chunks_.emplace_back();
+        for (size_t col = 0; col < column_infos_.size(); col++) {
+          auto fit = forced_semantics_.find(column_infos_[col].name);
+          if (fit == forced_semantics_.end()) {
+            column_chunks_.back().push_back(std::make_shared<ColBasedChunk>(column_infos_[col].name, params.max_level_name_length, params.max_levels, Semantics::UNKNOWN));
+          }
+          else {
+            column_chunks_.back().push_back(std::make_shared<ColBasedChunk>(column_infos_[col].name, params.max_level_name_length, params.max_levels, fit->second));
+          }
+        }
+      }
+#endif
       // We're now outside the parallel region.
       if (thread_exception) {
         std::rethrow_exception(thread_exception);

--- a/src/csv/colbased_loader.hpp
+++ b/src/csv/colbased_loader.hpp
@@ -520,7 +520,7 @@ namespace ParaText {
       else {
         const size_t sz(cat_buffer_.size());
         for (size_t i = 0; i < sz; i++) {
-          *it = cat_buffer_[i];
+          *it = (T)cat_buffer_[column_index][i];
           it++;
         }
       }
@@ -530,7 +530,7 @@ namespace ParaText {
     typename std::enable_if<std::is_same<T, std::string>::value, void>::type copy_column_impl(size_t column_index, OutputIterator it) const {
       if (column_infos_[column_index].semantics == Semantics::NUMERIC) {
         std::ostringstream ostr;
-        ostr << "string output iterator expected for column " << column_index;
+        ostr << "numeric output iterator expected for column " << column_index << ", not std::string element type.";
         throw std::logic_error(ostr.str());
       } else if (column_infos_[column_index].semantics == Semantics::TEXT) {
         //std::cout << "^^^" << column_index << std::endl;
@@ -554,7 +554,7 @@ namespace ParaText {
     typename std::enable_if<std::is_same<T, std::string>::value, void>::type copy_column_and_forget_impl(size_t column_index, OutputIterator it) const {
       if (column_infos_[column_index].semantics == Semantics::NUMERIC) {
         std::ostringstream ostr;
-        ostr << "string output iterator expected for column " << column_index;
+        ostr << "numeric output iterator expected for column " << column_index;
         throw std::logic_error(ostr.str());
       }
       else if (column_infos_[column_index].semantics == Semantics::TEXT) {

--- a/src/csv/colbased_worker.hpp
+++ b/src/csv/colbased_worker.hpp
@@ -116,6 +116,7 @@ public:
           if (buf[i] == ',') {
             process_token_number_only();
           }
+          else if (buf[i] == '\r') { /* do nothing. */}
           else if (buf[i] == '\n') {
             epos_line = current + i;
             if (epos_line - spos_line > 0) {
@@ -171,6 +172,7 @@ public:
               else if (buf[i] == ',') {
                 process_token();
               }
+              else if (buf[i] == '\r') { /* do nothing: dos wastes a byte each line. */ }
               else if (buf[i] == '\n') {
                 epos_line = current + i;
                 if (epos_line - spos_line > 0) {

--- a/src/csv/colbased_worker.hpp
+++ b/src/csv/colbased_worker.hpp
@@ -258,6 +258,7 @@ public:
     }
     if (definitely_string_) {
       parse_unquoted_string(token_.begin(), token_.end(), std::back_inserter(token_aux_));
+      convert_null_to_space(token_aux_.begin(), token_aux_.end());
       handlers_[column_index_]->process_categorical(token_aux_.begin(), token_aux_.end());
       token_aux_.clear();
       definitely_string_ = false;
@@ -346,6 +347,7 @@ public:
       }
       else {
         parse_unquoted_string(token_.begin(), token_.end(), std::back_inserter(token_aux_));
+        convert_null_to_space(token_aux_.begin(), token_aux_.end());
         handlers_[column_index_]->process_categorical(token_aux_.begin(), token_aux_.end());
         token_aux_.clear();
       }

--- a/src/csv/colbased_worker.hpp
+++ b/src/csv/colbased_worker.hpp
@@ -149,6 +149,12 @@ public:
             for (; i < nread; i++) {
               if (escape_jump_ > 0) {
                 escape_jump_--;
+                if (buf[i] == 'x') {
+                  escape_jump_ += 2;
+                }
+                else if (buf[i] == 'u') {
+                  escape_jump_ += 4;
+                }
                 token_.push_back(buf[i]);
               }
               else if (buf[i] == '\\') {

--- a/src/csv/colbased_worker.hpp
+++ b/src/csv/colbased_worker.hpp
@@ -257,7 +257,7 @@ public:
       throw std::logic_error(ostr.str());
     }
     if (definitely_string_) {
-      parse_quoted_string(token_.begin(), token_.end(), std::back_inserter(token_aux_), '\"');
+      parse_unquoted_string(token_.begin(), token_.end(), std::back_inserter(token_aux_));
       handlers_[column_index_]->process_categorical(token_aux_.begin(), token_aux_.end());
       token_aux_.clear();
       definitely_string_ = false;
@@ -345,7 +345,7 @@ public:
         handlers_[column_index_]->process_float(bsd_strtod(token_.begin(), token_.end()));
       }
       else {
-        parse_quoted_string(token_.begin(), token_.end(), std::back_inserter(token_aux_), '\"');
+        parse_unquoted_string(token_.begin(), token_.end(), std::back_inserter(token_aux_));
         handlers_[column_index_]->process_categorical(token_aux_.begin(), token_aux_.end());
         token_aux_.clear();
       }

--- a/src/csv/colbased_worker.hpp
+++ b/src/csv/colbased_worker.hpp
@@ -254,6 +254,8 @@ public:
           handlers_[column_index_]->process_integer(fast_atoi<long>(token_.begin(), token_.end()));
         }
       }
+    } else {
+      handlers_[column_index_]->process_integer(0);
     }
     column_index_++;
     token_.clear();

--- a/src/csv/colbased_worker.hpp
+++ b/src/csv/colbased_worker.hpp
@@ -86,6 +86,7 @@ public:
     size_t current = begin;
     size_t spos_line = begin, epos_line = begin;
     const size_t block_size = params.block_size;
+    convert_null_to_space_ = params.convert_null_to_space;
     char buf[block_size];
     in.seekg(current, std::ios_base::beg);
     definitely_string_ = false;
@@ -264,7 +265,9 @@ public:
     }
     if (definitely_string_) {
       parse_unquoted_string(token_.begin(), token_.end(), std::back_inserter(token_aux_));
-      convert_null_to_space(token_aux_.begin(), token_aux_.end());
+      if (convert_null_to_space_) {
+        convert_null_to_space(token_aux_.begin(), token_aux_.end());
+      }
       handlers_[column_index_]->process_categorical(token_aux_.begin(), token_aux_.end());
       token_aux_.clear();
       definitely_string_ = false;
@@ -353,7 +356,9 @@ public:
       }
       else {
         parse_unquoted_string(token_.begin(), token_.end(), std::back_inserter(token_aux_));
-        convert_null_to_space(token_aux_.begin(), token_aux_.end());
+        if (convert_null_to_space_) {
+          convert_null_to_space(token_aux_.begin(), token_aux_.end());
+        }
         handlers_[column_index_]->process_categorical(token_aux_.begin(), token_aux_.end());
         token_aux_.clear();
       }
@@ -386,6 +391,7 @@ private:
   char                                         quote_started_;
   size_t                                       column_index_;
   size_t                                       escape_jump_;
+  bool                                         convert_null_to_space_;
   std::exception_ptr                           thread_exception_;
 };
 }

--- a/src/csv/header_parser.hpp
+++ b/src/csv/header_parser.hpp
@@ -111,6 +111,7 @@ namespace CSV {
       char buf[block_size];
       char quote_started = 0;
       bool eoh_encountered = false;
+      bool soh_encountered = false;
       in_.seekg(0, std::ios_base::beg);
       while (current < length_ && !eoh_encountered) {
         if (current % block_size == 0) { /* The block is aligned. */
@@ -121,6 +122,15 @@ namespace CSV {
         }
         size_t nread = in_.gcount();
         size_t i = 0;
+        /* ignore leading whitespace in the file. */
+        for (; i < nread && !soh_encountered;) {
+          if (isspace(buf[i])) {
+            i++; /* eat the whitespace. */
+          } else {
+            soh_encountered = true;
+            /* do not do i++. we need to process it like non-whitespace */
+          }
+        }
         while (i < nread && !eoh_encountered) {
           if (quote_started) {
             for (; i < nread; i++) {

--- a/src/csv/header_parser.hpp
+++ b/src/csv/header_parser.hpp
@@ -89,7 +89,7 @@ namespace CSV {
 
       std::string transformed_name;
       parse_unquoted_string(name.begin(), name.end(), std::back_inserter(transformed_name));
-      convert_null_to_space(name.begin(), name.end());
+      convert_null_to_space(transformed_name.begin(), transformed_name.end());
       column_names_.push_back(transformed_name);
     }
     

--- a/src/csv/header_parser.hpp
+++ b/src/csv/header_parser.hpp
@@ -151,14 +151,7 @@ namespace CSV {
               else if (buf[i] == '\"' || buf[i] == '\'') {
                 quote_started = buf[i];
                 i++;
-                for (; i < nread; i++) {
-                  if (buf[i] == quote_started) {
-                    quote_started = 0;
-                    i++;
-                    break;
-                  }
-                  token.push_back(buf[i]);
-                }
+                break;
               }
               else if (buf[i] == ',') {
                 add_column_name(token);
@@ -176,9 +169,9 @@ namespace CSV {
                 token.push_back(buf[i]);
               }
             }
-            current += nread;
           }
         }
+        current += nread;
       }
       std::unordered_set<std::string> cnset;
       for (auto &cname : column_names_) {

--- a/src/csv/header_parser.hpp
+++ b/src/csv/header_parser.hpp
@@ -33,6 +33,8 @@
 #include <fstream>
 #include <unordered_set>
 
+#include "util/strings.hpp"
+
 namespace ParaText {
 
 namespace CSV {
@@ -84,7 +86,11 @@ namespace CSV {
      */
     void add_column_name(const std::string &name) {
       //std::cerr << "col " << column_names_.size() << ": " << name << std::endl;
-      column_names_.push_back(name);
+
+      std::string transformed_name;
+      parse_unquoted_string(name.begin(), name.end(), std::back_inserter(transformed_name));
+      convert_null_to_space(name.begin(), name.end());
+      column_names_.push_back(transformed_name);
     }
     
     /*
@@ -101,10 +107,12 @@ namespace CSV {
       std::string token;
       size_t current = 0;
       size_t block_size = 4096;
+      size_t escape_jump = 0;
       char buf[block_size];
       char quote_started = 0;
+      bool eoh_encountered = false;
       in_.seekg(0, std::ios_base::beg);
-      while (current < length_) {
+      while (current < length_ && !eoh_encountered) {
         if (current % block_size == 0) { /* The block is aligned. */
           in_.read(buf, std::min(length_ - current, block_size));
         }
@@ -113,50 +121,65 @@ namespace CSV {
         }
         size_t nread = in_.gcount();
         size_t i = 0;
-        if (quote_started) {
-          for (; i < nread; i++) {
-            if (buf[i] == quote_started) {
-              quote_started = 0;
-              break;
+        while (i < nread && !eoh_encountered) {
+          if (quote_started) {
+            for (; i < nread; i++) {
+              if (escape_jump > 0) {
+                escape_jump--;
+              }
+              else if (buf[i] == '\\') {
+                escape_jump = 1;
+              }
+              else if (buf[i] == quote_started) {
+                i++;
+                quote_started = 0;
+                break;
+              }
+              token.push_back(buf[i]);
             }
-            token.push_back(buf[i]);
           }
-        }
-        for (; i < nread; i++) {
-          switch (buf[i]) {
-          case '\'':
-          case '\"':
-            {
-              quote_started = buf[i];
-              i++;
-              for (; i < nread; i++) {
-                if (buf[i] == quote_started) {
-                  quote_started = false;
-                  break;
+          else {
+            for (; i < nread; i++) {
+              if (escape_jump > 0) {
+                token.push_back(buf[i]);
+                escape_jump--;
+              }
+              else if (buf[i] == '\\') {
+                token.push_back(buf[i]);
+                escape_jump = 1;
+              }
+              else if (buf[i] == '\"' || buf[i] == '\'') {
+                quote_started = buf[i];
+                i++;
+                for (; i < nread; i++) {
+                  if (buf[i] == quote_started) {
+                    quote_started = 0;
+                    i++;
+                    break;
+                  }
+                  token.push_back(buf[i]);
                 }
+              }
+              else if (buf[i] == ',') {
+                add_column_name(token);
+                token.clear();
+              }
+              else if (buf[i] == '\n') {
+                add_column_name(token);
+                token.clear();
+                end_of_header_ = current + i;
+                eoh_encountered = true;
+                i++;
+                break;
+              }
+              else {
                 token.push_back(buf[i]);
               }
             }
-            //std::cout << token << std::endl;
-            break;
-          case ',':
-            add_column_name(token);
-            token.clear();
-            break;
-          case '\n':
-            add_column_name(token);
-            token.clear();
-            end_of_header_ = current + i;
-            goto header_finished;
-            break;
-          default:
-            token.push_back(buf[i]);
-            break;
+            current += nread;
           }
         }
-        current += nread;
       }
-    header_finished:
       std::unordered_set<std::string> cnset;
       for (auto &cname : column_names_) {
         cnset.insert(cname);

--- a/src/csv/header_parser.hpp
+++ b/src/csv/header_parser.hpp
@@ -123,7 +123,7 @@ namespace CSV {
         size_t nread = in_.gcount();
         size_t i = 0;
         /* ignore leading whitespace in the file. */
-        for (; i < nread && !soh_encountered;) {
+        while (i < nread && !soh_encountered) {
           if (isspace(buf[i])) {
             i++; /* eat the whitespace. */
           } else {
@@ -166,7 +166,8 @@ namespace CSV {
               else if (buf[i] == ',') {
                 add_column_name(token);
                 token.clear();
-              }
+              }              
+              else if (buf[i] == '\r') { /* do nothing: dos wastes a byte each line. */ }
               else if (buf[i] == '\n') {
                 add_column_name(token);
                 token.clear();
@@ -182,6 +183,9 @@ namespace CSV {
           }
         }
         current += nread;
+      }
+      if (!soh_encountered) { /* If this is just a file of whitespace, then the end of header is the last pos in the file. */
+        end_of_header_ = current;
       }
       std::unordered_set<std::string> cnset;
       for (auto &cname : column_names_) {

--- a/src/csv/rowbased_loader.hpp
+++ b/src/csv/rowbased_loader.hpp
@@ -61,12 +61,12 @@ public:
     std::vector<std::thread> threads;
     std::vector<std::shared_ptr<RowBasedParseWorker> > workers;
     for (size_t worker_id = 0; worker_id < params.num_threads; worker_id++) {
-      size_t start_of_chunk, end_of_chunk = 0;
+      long start_of_chunk, end_of_chunk = 0;
       std::tie(start_of_chunk, end_of_chunk) = chunker_.get_chunk(worker_id);
       
       /* If the chunk was eliminated because its entirety represents quoted
          text, do not spawn a worker thread for it. */
-      if (start_of_chunk == end_of_chunk) {
+      if (start_of_chunk < 0 || end_of_chunk < 0) {
         continue;
       }
       workers.push_back(std::make_shared<RowBasedParseWorker>(start_of_chunk, end_of_chunk, length_, params.block_size, params.compression == Compression::SNAPPY));

--- a/src/diagnostic/newline_counter.hpp
+++ b/src/diagnostic/newline_counter.hpp
@@ -113,10 +113,9 @@ private:
       std::exception_ptr thread_exception;
       chunker_.process(filename, 0, params.num_threads, params.allow_quoted_newlines);
       for (size_t worker_id = 0; worker_id < chunker_.num_chunks(); worker_id++) {
-        size_t start_of_chunk = 0, end_of_chunk = 0;
+        long start_of_chunk = 0, end_of_chunk = 0;
         std::tie(start_of_chunk, end_of_chunk) = chunker_.get_chunk(worker_id);
-        
-        if (start_of_chunk == end_of_chunk) {
+        if (start_of_chunk < 0 || end_of_chunk < 0) {
           continue;
         }
         workers.push_back(std::make_shared<NewlineCountWorker>(start_of_chunk, end_of_chunk, params.block_size));

--- a/src/diagnostic/parse_and_sum.hpp
+++ b/src/diagnostic/parse_and_sum.hpp
@@ -198,10 +198,9 @@ private:
         chunker_.process(filename, 0, params.num_threads, params.allow_quoted_newlines);
       }
       for (size_t worker_id = 0; worker_id < chunker_.num_chunks(); worker_id++) {
-        size_t start_of_chunk = 0, end_of_chunk = 0;
+        long start_of_chunk = 0, end_of_chunk = 0;
         std::tie(start_of_chunk, end_of_chunk) = chunker_.get_chunk(worker_id);
-        
-        if (start_of_chunk == end_of_chunk) {
+        if (start_of_chunk < 0 || end_of_chunk < 0) {
           continue;
         }
         workers.push_back(std::make_shared<ParseAndSumWorker<TypeCheck> >(start_of_chunk, end_of_chunk, params.block_size, header_parser_.get_num_columns()));

--- a/src/generic/chunker.hpp
+++ b/src/generic/chunker.hpp
@@ -36,6 +36,7 @@
 #include <unistd.h>
 #include <thread>
 #include <sstream>
+#include <vector>
 
 #include "quote_adjustment_worker.hpp"
 

--- a/src/generic/chunker.hpp
+++ b/src/generic/chunker.hpp
@@ -220,7 +220,7 @@ namespace ParaText {
       size_t next_wid = 1;
       quotes_so_far += workers[cur_wid]->get_num_quotes();
       while (cur_wid < workers.size()) {
-        if (end_of_chunk_[cur_wid] == start_of_chunk_[cur_wid]) {
+        if (end_of_chunk_[cur_wid] < -1 || start_of_chunk_[cur_wid] < -1) {
           start_of_chunk_[cur_wid] = -1;
           end_of_chunk_[cur_wid] = -1;
           cur_wid++;

--- a/src/generic/encoding.hpp
+++ b/src/generic/encoding.hpp
@@ -1,4 +1,8 @@
 /*
+
+    ParaText: parallel text reading
+    Copyright (C) 2016. wise.io, Inc.
+
    Licensed to the Apache Software Foundation (ASF) under one
    or more contributor license agreements.  See the NOTICE file
    distributed with this work for additional information
@@ -15,23 +19,26 @@
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
+ */
 
-   Copyright (C) wise.io, Inc. 2016.
-*/
-#ifndef PARATEXT_PARACSV_HPP
-#define PARATEXT_PARACSV_HPP
+/*
+  Coder: Damian Eads.
+ */
 
-#include "generic/parse_params.hpp"
+#ifndef PARATEXT_ENCODING_HPP
+#define PARATEXT_ENCODING_HPP
 
-size_t get_num_cores();
+namespace ParaText {
+  typedef enum {UNKNOWN_BYTES, UNICODE_UTF8, ASCII} Encoding;
 
-std::string as_quoted_string(const std::string &s, bool do_not_escape_newlines = false);
+  struct as_raw_bytes {
+    std::string val;
+  };
+  
+  struct as_utf8 {
+    std::string val;
+  };
 
-ParaText::as_raw_bytes get_random_string(size_t length, long seed, long min = 0, long max = 255);
-ParaText::as_utf8 get_random_string_utf8(size_t num_sequences, long seed, bool include_null = true);
-
-size_t get_string_length(const std::string &s);
-
-bool are_strings_equal(const std::string &x, const std::string &y);
+}
 
 #endif

--- a/src/generic/parse_params.hpp
+++ b/src/generic/parse_params.hpp
@@ -48,10 +48,11 @@ namespace ParaText {
   };
 
   struct ParseParams {
-    ParseParams() : no_header(false), number_only(false), block_size(32768), num_threads(16), allow_quoted_newlines(false),  max_level_name_length(std::numeric_limits<size_t>::max()), max_levels(std::numeric_limits<size_t>::max()), compression(Compression::NONE), parser_type(ParserType::COL_BASED) {}
+    ParseParams() : no_header(false), number_only(false), convert_null_to_space(true), block_size(32768), num_threads(16), allow_quoted_newlines(false),  max_level_name_length(std::numeric_limits<size_t>::max()), max_levels(std::numeric_limits<size_t>::max()), compression(Compression::NONE), parser_type(ParserType::COL_BASED) {}
     bool no_header;
     bool number_only;
     bool compute_sum;
+    bool convert_null_to_space;
     size_t block_size;
     size_t num_threads;
     bool allow_quoted_newlines;

--- a/src/generic/parse_params.hpp
+++ b/src/generic/parse_params.hpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <limits>
+#include "generic/encoding.hpp"
 
 namespace ParaText {
 
@@ -37,6 +38,9 @@ namespace ParaText {
   typedef enum {NONE, SNAPPY, MSGPACK} Compression;
 
   typedef enum {CATEGORICAL, NUMERIC, TEXT, UNKNOWN} Semantics;
+
+  template <class T, int InEncoding, int OutEncoding>
+  struct TagEncoding {};
 
   struct ColumnInfo {
     std::string name;

--- a/src/generic/parse_params.hpp
+++ b/src/generic/parse_params.hpp
@@ -44,7 +44,7 @@ namespace ParaText {
   };
 
   struct ParseParams {
-    ParseParams() : no_header(false), number_only(false), block_size(32768), num_threads(16), allow_quoted_newlines(false),  max_level_name_length(std::numeric_limits<size_t>::max()), max_levels(std::numeric_limits<size_t>::max()), compression(Compression::NONE), parser_type(ParserType::ROW_BASED) {}
+    ParseParams() : no_header(false), number_only(false), block_size(32768), num_threads(16), allow_quoted_newlines(false),  max_level_name_length(std::numeric_limits<size_t>::max()), max_levels(std::numeric_limits<size_t>::max()), compression(Compression::NONE), parser_type(ParserType::COL_BASED) {}
     bool no_header;
     bool number_only;
     bool compute_sum;

--- a/src/generic/quote_adjustment_worker.hpp
+++ b/src/generic/quote_adjustment_worker.hpp
@@ -63,6 +63,7 @@ public:
     char buf[block_size];
     in.seekg(chunk_start_, std::ios_base::beg);
     size_t current = chunk_start_;
+    size_t escape_count = 0;
     bool in_quote = false;
     while (current <= chunk_end_) {
       in.read(buf, std::min(chunk_end_ - current + 1, block_size));
@@ -74,7 +75,18 @@ public:
       while (i < nread && first_unquoted_newline_ < 0 && first_quoted_newline_ < 0) {
         if (in_quote) {
           for (; i < nread; i++) {
-            if (buf[i] == '\"') {
+            if (escape_count > 0) {
+              if (buf[i] == 'x') {
+                escape_count = 2;
+              }
+              else {
+                escape_count--;
+              }
+            }
+            else if (buf[i] == '\\') {
+              escape_count = 1;
+            }
+            else if (buf[i] == '\"') {
               num_quotes_++;
               in_quote = false;
               i++;
@@ -89,7 +101,18 @@ public:
         }
         else {
           for (; i < nread; i++) {
-            if (buf[i] == '\"') {
+            if (escape_count > 0) {
+              if (buf[i] == 'x') {
+                escape_count = 2;
+              }
+              else {
+                escape_count--;
+              }
+            }
+            else if (buf[i] == '\\') {
+              escape_count = 1;
+            }
+            else if (buf[i] == '\"') {
               num_quotes_++;
               in_quote = true;
               i++;
@@ -106,7 +129,18 @@ public:
       while (i < nread && first_unquoted_newline_ < 0) {
         if (in_quote) {
           for (; i < nread; i++) {
-            if (buf[i] == '\"') {
+            if (escape_count > 0) {
+              if (buf[i] == 'x') {
+                escape_count = 2;
+              }
+              else {
+                escape_count--;
+              }
+            }
+            else if (buf[i] == '\\') {
+              escape_count = 1;
+            }
+            else if (buf[i] == '\"') {
               num_quotes_++;
               in_quote = false;
               i++;
@@ -116,7 +150,18 @@ public:
         }
         else {
           for (; i < nread; i++) {
-            if (buf[i] == '\"') {
+            if (escape_count > 0) {
+              if (buf[i] == 'x') {
+                escape_count = 2;
+              }
+              else {
+                escape_count--;
+              }
+            }
+            else if (buf[i] == '\\') {
+              escape_count = 1;
+            }
+            else if (buf[i] == '\"') {
               num_quotes_++;
               in_quote = true;
               i++;
@@ -133,7 +178,18 @@ public:
       while (i < nread && first_quoted_newline_ < 0) {
         if (in_quote) {
           for (; i < nread; i++) {
-            if (buf[i] == '\"') {
+            if (escape_count > 0) {
+              if (buf[i] == 'x') {
+                escape_count = 2;
+              }
+              else {
+                escape_count--;
+              }
+            }
+            else if (buf[i] == '\\') {
+              escape_count = 1;
+            }
+            else if (buf[i] == '\"') {
               num_quotes_++;
               in_quote = false;
               i++;
@@ -164,7 +220,18 @@ public:
       while (i < nread) {
         if (in_quote) {
           for (; i < nread; i++) {
-            if (buf[i] == '\"') {
+            if (escape_count > 0) {
+              if (buf[i] == 'x') {
+                escape_count = 2;
+              }
+              else {
+                escape_count--;
+              }
+            }
+            else if (buf[i] == '\\') {
+              escape_count = 1;
+            }
+            else if (buf[i] == '\"') {
               num_quotes_++;
               in_quote = false;
               i++;
@@ -174,7 +241,18 @@ public:
         }
         else {
           for (; i < nread; i++) {
-            if (buf[i] == '\"') {
+            if (escape_count > 0) {
+              if (buf[i] == 'x') {
+                escape_count = 2;
+              }
+              else {
+                escape_count--;
+              }
+            }
+            else if (buf[i] == '\\') {
+              escape_count = 1;
+            }
+            else if (buf[i] == '\"') {
               num_quotes_++;
               in_quote = true;
               i++;

--- a/src/generic/quote_adjustment_worker.hpp
+++ b/src/generic/quote_adjustment_worker.hpp
@@ -179,7 +179,13 @@ public:
         }
         else {
           for (; i < nread; i++) {
-            if (buf[i] == '\"') {
+            if (escape_count > 0) {
+              escape_count--;
+            }
+            else if (buf[i] == '\\') {
+              escape_count = 1;
+            }
+            else if (buf[i] == '\"') {
               num_quotes_++;
               in_quote = true;
               i++;

--- a/src/generic/quote_adjustment_worker.hpp
+++ b/src/generic/quote_adjustment_worker.hpp
@@ -56,7 +56,6 @@ public:
   }
 
   void parse_impl(const std::string &filename) {
-
     std::ifstream in;
     in.open(filename.c_str());
     const size_t block_size = 32768;

--- a/src/generic/quote_adjustment_worker.hpp
+++ b/src/generic/quote_adjustment_worker.hpp
@@ -76,12 +76,7 @@ public:
         if (in_quote) {
           for (; i < nread; i++) {
             if (escape_count > 0) {
-              if (buf[i] == 'x') {
-                escape_count = 2;
-              }
-              else {
-                escape_count--;
-              }
+              escape_count--;
             }
             else if (buf[i] == '\\') {
               escape_count = 1;
@@ -102,12 +97,7 @@ public:
         else {
           for (; i < nread; i++) {
             if (escape_count > 0) {
-              if (buf[i] == 'x') {
-                escape_count = 2;
-              }
-              else {
-                escape_count--;
-              }
+              escape_count--;
             }
             else if (buf[i] == '\\') {
               escape_count = 1;
@@ -130,12 +120,7 @@ public:
         if (in_quote) {
           for (; i < nread; i++) {
             if (escape_count > 0) {
-              if (buf[i] == 'x') {
-                escape_count = 2;
-              }
-              else {
-                escape_count--;
-              }
+              escape_count--;
             }
             else if (buf[i] == '\\') {
               escape_count = 1;
@@ -151,12 +136,7 @@ public:
         else {
           for (; i < nread; i++) {
             if (escape_count > 0) {
-              if (buf[i] == 'x') {
-                escape_count = 2;
-              }
-              else {
-                escape_count--;
-              }
+              escape_count--;
             }
             else if (buf[i] == '\\') {
               escape_count = 1;
@@ -179,12 +159,7 @@ public:
         if (in_quote) {
           for (; i < nread; i++) {
             if (escape_count > 0) {
-              if (buf[i] == 'x') {
-                escape_count = 2;
-              }
-              else {
-                escape_count--;
-              }
+              escape_count--;
             }
             else if (buf[i] == '\\') {
               escape_count = 1;
@@ -221,12 +196,7 @@ public:
         if (in_quote) {
           for (; i < nread; i++) {
             if (escape_count > 0) {
-              if (buf[i] == 'x') {
-                escape_count = 2;
-              }
-              else {
-                escape_count--;
-              }
+              escape_count--;
             }
             else if (buf[i] == '\\') {
               escape_count = 1;
@@ -242,12 +212,7 @@ public:
         else {
           for (; i < nread; i++) {
             if (escape_count > 0) {
-              if (buf[i] == 'x') {
-                escape_count = 2;
-              }
-              else {
-                escape_count--;
-              }
+              escape_count--;
             }
             else if (buf[i] == '\\') {
               escape_count = 1;

--- a/src/generic/quote_adjustment_worker.hpp
+++ b/src/generic/quote_adjustment_worker.hpp
@@ -264,6 +264,17 @@ public:
     first_quoted_newline_ = 0;
   }
 
+  void combine_adjacent(const QuoteNewlineAdjustmentWorker &other) {
+    chunk_end_ = other.chunk_end_;
+    num_quotes_ += other.num_quotes_;
+    if (first_unquoted_newline_ < 0) {
+      first_unquoted_newline_ = other.first_unquoted_newline_;
+    }
+    if (first_quoted_newline_ < 0) {
+      first_quoted_newline_ = other.first_quoted_newline_;
+    }
+  }
+
 private:
   size_t chunk_start_;
   size_t chunk_end_;

--- a/src/generic/quote_adjustment_worker.hpp
+++ b/src/generic/quote_adjustment_worker.hpp
@@ -82,6 +82,9 @@ public:
             }
             else if (buf[i] == '\"') {
               num_quotes_++;
+#ifdef PARATEXT_DEBUG_QUOTE
+              std::cerr << "[Q1:" << (current + i) << ":" << num_quotes_ << ":" << escape_count;
+#endif
               in_quote = false;
               i++;
               break;
@@ -103,6 +106,9 @@ public:
             }
             else if (buf[i] == '\"') {
               num_quotes_++;
+#ifdef PARATEXT_DEBUG_QUOTE
+              std::cerr << "[Q2:" << (current + i) << ":" << num_quotes_ << ":" << escape_count;
+#endif
               in_quote = true;
               i++;
               break;
@@ -111,7 +117,7 @@ public:
               first_unquoted_newline_ = current + i;
               i++;
               break;
-            }            
+            }
           }
         }
       }
@@ -126,6 +132,9 @@ public:
             }
             else if (buf[i] == '\"') {
               num_quotes_++;
+#ifdef PARATEXT_DEBUG_QUOTE
+              std::cerr << "[Q3:" << (current + i) << ":" << num_quotes_ << ":" << escape_count;
+#endif
               in_quote = false;
               i++;
               break;
@@ -142,6 +151,9 @@ public:
             }
             else if (buf[i] == '\"') {
               num_quotes_++;
+#ifdef PARATEXT_DEBUG_QUOTE
+              std::cerr << "[Q4:" << (current + i) << ":" << num_quotes_ << ":" << escape_count;
+#endif
               in_quote = true;
               i++;
               break;
@@ -165,6 +177,9 @@ public:
             }
             else if (buf[i] == '\"') {
               num_quotes_++;
+#ifdef PARATEXT_DEBUG_QUOTE
+              std::cerr << "[Q5:" << (current + i) << ":" << num_quotes_ << ":" << escape_count;
+#endif
               in_quote = false;
               i++;
               break;
@@ -186,6 +201,9 @@ public:
             }
             else if (buf[i] == '\"') {
               num_quotes_++;
+#ifdef PARATEXT_DEBUG_QUOTE
+              std::cerr << "[Q6:" << (current + i) << ":" << num_quotes_ << ":" << escape_count;
+#endif
               in_quote = true;
               i++;
               break;
@@ -208,6 +226,9 @@ public:
             }
             else if (buf[i] == '\"') {
               num_quotes_++;
+#ifdef PARATEXT_DEBUG_QUOTE
+              std::cerr << "[Q7:" << (current + i) << ":" << num_quotes_ << ":" << escape_count;
+#endif
               in_quote = false;
               i++;
               break;
@@ -224,6 +245,9 @@ public:
             }
             else if (buf[i] == '\"') {
               num_quotes_++;
+#ifdef PARATEXT_DEBUG_QUOTE
+              std::cerr << "[Q8:" << (current + i) << ":" << num_quotes_ << ":" << escape_count;
+#endif
               in_quote = true;
               i++;
               break;

--- a/src/paratext_internal.cpp
+++ b/src/paratext_internal.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "paratext_internal.hpp"
+#include "util/strings.hpp"
 
 #include <string>
 #include <type_traits>
@@ -26,4 +27,17 @@
 
 size_t get_num_cores() {
   return std::thread::hardware_concurrency();
+}
+
+std::string as_quoted_string(const std::string &s, bool do_not_escape_newlines) {
+  return get_quoted_string(s.begin(), s.end(), true, do_not_escape_newlines);
+}
+
+std::string get_random_string(size_t length, size_t min_char, size_t max_char) {
+  std::string s(length, ' ');
+  size_t range = (max_char - min_char) + 1;
+  for (size_t i = 0; i < length; i++) {
+    s[i] = random() % range + min_char;
+  }
+  return s;
 }

--- a/src/paratext_internal.hpp
+++ b/src/paratext_internal.hpp
@@ -25,4 +25,8 @@
 
 size_t get_num_cores();
 
+std::string as_quoted_string(const std::string &s, bool do_not_escape_newlines = false);
+
+std::string get_random_string(size_t length, size_t min_char, size_t max_char);
+
 #endif

--- a/src/paratext_internal.i
+++ b/src/paratext_internal.i
@@ -33,7 +33,7 @@
 #warning "no SWIG typemaps defined for the target language"
 #endif
 
-%include "std_string.i"
+ //%include "std_string.i"
 %include "std_vector.i"
 %include "std_pair.i"
 
@@ -84,6 +84,11 @@ namespace std {
 %include "diagnostic/parse_and_sum.hpp"
 %{
 #include "diagnostic/parse_and_sum.hpp"
+%}
+
+%include "util/safe_string_output.hpp"
+%{
+#include "util/safe_string_output.hpp"
 %}
 
 #if defined(PARATEXT_ROWBASED_CSV)

--- a/src/paratext_internal.i
+++ b/src/paratext_internal.i
@@ -38,6 +38,7 @@
 %include "std_pair.i"
 
 %ignore ParaText::CSV::ColBasedPopulator::get_type_index() const;
+%ignore ParaText::CSV::StringVectorPopulator::get_type_index() const;
 %ignore ParaText::CSV::ColBasedLoader::get_type_index(size_t) const;
 %ignore ParaText::CSV::ColBasedIterator::operator++();
 %ignore ParaText::CSV::ColBasedIterator::operator++(int);
@@ -56,6 +57,11 @@ namespace std {
 %include "generic/parse_params.hpp"
 %{
 #include "generic/parse_params.hpp"
+%}
+
+%include "generic/encoding.hpp"
+%{
+#include "generic/encoding.hpp"
 %}
 
 //////// CSV-loading Stuff

--- a/src/python/numpy_helper.hpp
+++ b/src/python/numpy_helper.hpp
@@ -61,11 +61,7 @@ template <> struct numpy_type<unsigned long>  { static const long id = NPY_ULONG
 #endif
 
 inline PyObject *as_python_string(const std::string &in) {
-#if PY_MAJOR_VERSION < 3
-  return PyString_FromStringAndSize(in.c_str(), in.size());
-#else
   return PyUnicode_FromStringAndSize(in.c_str(), in.size());
-#endif
 }
 
 template <class Container, class Enable=void>

--- a/src/python/numpy_helper.hpp
+++ b/src/python/numpy_helper.hpp
@@ -69,7 +69,12 @@ template <>
 struct AsPythonString<ParaText::Encoding::UNKNOWN_BYTES,
                       ParaText::Encoding::UNICODE_UTF8> {
   PyObject *operator()(const std::string &in) const {
-    return PyUnicode_FromStringAndSize(in.c_str(), in.size());
+    PyObject *attempt = PyUnicode_FromStringAndSize(in.c_str(), in.size());
+    if (attempt == NULL) {
+       PyErr_Clear();
+       attempt = PyBytes_FromStringAndSize(in.c_str(), in.size());
+    }
+    return attempt;
   }
 };
 
@@ -101,7 +106,12 @@ template <>
 struct AsPythonString<ParaText::Encoding::UNICODE_UTF8,
                       ParaText::Encoding::UNICODE_UTF8> {
   PyObject *operator()(const std::string &in) const {
-    return PyUnicode_FromStringAndSize(in.c_str(), in.size());
+    PyObject *attempt = PyUnicode_FromStringAndSize(in.c_str(), in.size());
+    if (attempt == NULL) {
+       PyErr_Clear();
+       attempt = PyBytes_FromStringAndSize(in.c_str(), in.size());
+    }
+    return attempt;
   }
 };
 

--- a/src/python/processor.hpp
+++ b/src/python/processor.hpp
@@ -1,0 +1,185 @@
+/*
+  File: processor.bhpp
+
+  Author: Damian Eads, PhD
+
+  Copyright (C) wise.io, Inc. 2015.
+ */
+
+#ifndef WISEIO_PROCESSOR_HPP
+#define WISEIO_PROCESSOR_HPP
+
+#include <string>
+#include <exception>
+
+#ifdef PARATEXT_DATE_TIME
+#include <boost/date_time/posix_time/posix_time.hpp>
+#endif
+
+namespace ParaText {
+
+  /*
+    A generic call-back interface for processing a sequence of
+    variably-typed objects coming from a different language.
+
+    For example, if a C++ functor requires a sequence, it
+    can implement the interface of this class.
+
+    WiseTransfer will iterate over the array, list, tuple,
+    iterable object, or sequence object. When an element of a
+    string is found, it calls process_string. If it is floating
+    point, process_float is called. If it is a long integer,
+    process_long is called.
+   */
+  class CallbackProcessor {
+  public:
+
+    /*
+      The base constructor. Does nothing in this part of sub-object
+      construction.
+     */
+    CallbackProcessor();
+
+    /*
+      The destructor deletes this callback processor and deallocates
+      any temporary resources needed.
+     */
+    virtual ~CallbackProcessor();
+    
+    /*
+      Tells the functor to ingest the next element, which is a string.
+     */
+    virtual void process_string(const char *begin, const char *end) = 0;
+
+    /*
+      Tells the functor to ingest the next element, which is a float.
+     */
+    virtual void process_float(float fval) = 0;
+
+    /*
+      Tells the functor to ingest the next element, which is a long.
+     */
+    virtual void process_long(long lval) = 0;
+
+    /*
+      Tells the functor to ingest the next element, which is a bool.
+     */
+    virtual void process_bool(bool bval) = 0;
+
+    /*
+      Asks the functor to translate an exception thrown while calling
+      one of the process_XXX methods into a string.
+     */
+    virtual void process_exception(std::exception_ptr ptr, std::string &text) = 0;
+
+    /*
+      Process the next sparse value.
+     */
+    virtual void process_sparse(size_t row_index, size_t col_index, float value) = 0;
+
+
+    /*
+      Process an empty sparse row.
+     */
+    virtual void process_sparse(size_t row_index) = 0;
+  };
+
+  /*
+    An enumerated type for identifying the type of element in an
+    IteratorProcessor.
+   */
+  enum class IteratorElementType {STRING, LONG, BOOL, FLOAT, DATETIME};
+
+  /*
+    An IteratorProcessor (iterproc for short) generic interface for
+    manipulating an iterator over primitive types in another language.
+
+    An iterproc X can be queried if there are any more elements remaining
+    as follows::
+
+        while (X.has_next()) {
+           switch (X.get_type()) {
+           case IteratorElementType::STRING:
+              ...
+              break;
+           }
+           X.advance();
+        }
+
+    The get_type() function returns the type of the current element.
+    The advance() function advances the iterator to the next element.
+    The element that the iterator is currently pointing to can be
+    retrieved with:
+
+          X.get_string()
+          X.get_float()
+          X.get_long()
+          X.get_bool()
+
+    
+   */
+  class IteratorProcessor {
+  public:
+    /*
+      The base constructor for an IteratorProcessor. This part of
+      the sub-object construction does nothing.
+     */
+    IteratorProcessor() {}
+
+    /*
+      A virtual destructor for the iterator processor.
+    */
+    virtual ~IteratorProcessor() {}
+
+    /*
+      The type of the element to which the iterator currently points.
+    */
+    virtual IteratorElementType get_type() const = 0;
+
+    /*
+      Retrieves a string representation of the current element.
+     */
+    virtual std::string get_string() const = 0;
+
+    /*
+      Retrieves a float at the current element.
+     */
+    virtual double get_float() const = 0;
+
+    /*
+      Retrieves a long at the current element.
+     */
+    virtual long get_long() const = 0;
+
+#ifdef PARATEXT_DATE_TIME
+    /*
+      Retrieves a date time at the current element.
+     */
+    virtual boost::posix_time::ptime get_datetime() const = 0;
+#endif
+
+    /*
+      Retrieves a bool at the current element.
+     */
+    virtual bool get_bool() const = 0;
+
+    /*
+      Returns true if and only if this iterator has another element
+      past the current element.
+     */
+    virtual bool has_next() const = 0;
+
+    /*
+      Advances the iterator to the next element.
+     */
+    virtual void advance() = 0;
+
+    /*
+      Returns the number of elements this iterator processes. If this
+      number is not known, std::numeric_limits<size_t>::max() is used
+      instead.
+     */
+    virtual size_t size() const = 0;
+  };
+}
+#endif

--- a/src/python/python.i
+++ b/src/python/python.i
@@ -28,6 +28,23 @@
   import_array();
 %}
 
+#define PARATEXT_TYPEMAP_EXCEPTION_START try {
+
+#define PARATEXT_TYPEMAP_EXCEPTION_END    } catch (const std::string &e) {\
+      std::string s = e;\
+      SWIG_exception(SWIG_RuntimeError, s.c_str());\
+      SWIG_fail;\
+    } catch (const std::exception &e) {\
+      SWIG_exception(SWIG_RuntimeError, e.what());\
+      SWIG_fail;\
+    } catch (const char *emsg) {\
+      SWIG_exception(SWIG_RuntimeError, emsg);\
+      SWIG_fail;\
+    } catch (...) {\
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");\
+      SWIG_fail;\
+    }
+
 %exception {
     try {
         $action
@@ -35,8 +52,11 @@
       std::string s = e;
       SWIG_exception(SWIG_RuntimeError, s.c_str());
       SWIG_fail;
-    } catch (std::exception &e) {
+    } catch (const std::exception &e) {
       SWIG_exception(SWIG_RuntimeError, e.what());
+      SWIG_fail;
+    } catch (const char *emsg) {
+      SWIG_exception(SWIG_RuntimeError, emsg);
       SWIG_fail;
     } catch (...) {
       SWIG_exception(SWIG_RuntimeError, "unknown exception");
@@ -109,13 +129,17 @@
 */
 
 %typemap(in) const std::string & {
+  PARATEXT_TYPEMAP_EXCEPTION_START
   std::unique_ptr<std::string> result(new std::string(ParaText::get_as_string($input, 0)));
   $1 = result.release();
+  PARATEXT_TYPEMAP_EXCEPTION_END
 }
 
 %typemap(in) std::string & {
+  PARATEXT_TYPEMAP_EXCEPTION_START
   std::unique_ptr<std::string> result(new std::string(ParaText::get_as_string($input, 0)));
   $1 = result.release();
+  PARATEXT_TYPEMAP_EXCEPTION_END
 }
 
 %typemap(freearg) const std::string & {

--- a/src/python/python.i
+++ b/src/python/python.i
@@ -96,7 +96,66 @@
   $result = (PyObject*)::build_populator<ParaText::CSV::StringVectorPopulator>($1);
 }
 
+/*
+%typemap(in) const std::string & {
+  std::string result(ParaText::get_as_string($input, 0));
+  $1 = &result;
+}
+
+%typemap(in) std::string & {
+  std::string result(ParaText::get_as_string($input, 0));
+  $1 = &result;
+}
+*/
+
+%typemap(in) const std::string & {
+  std::unique_ptr<std::string> result(new std::string(ParaText::get_as_string($input, 0)));
+  $1 = result.release();
+}
+
+%typemap(in) std::string & {
+  std::unique_ptr<std::string> result(new std::string(ParaText::get_as_string($input, 0)));
+  $1 = result.release();
+}
+
+%typemap(freearg) const std::string & {
+  delete $1;
+}
+
+%typemap(freearg) std::string & {
+  delete $1;
+}
+
+
+%typemap(out) const std::string & {
+  AsPythonString<ParaText::Encoding::UNKNOWN_BYTES, ParaText::Encoding::UNICODE_UTF8> helper;
+  $result = helper(*$1);
+}
+
+%typemap(out) std::string & {
+  AsPythonString<ParaText::Encoding::UNKNOWN_BYTES, ParaText::Encoding::UNICODE_UTF8> helper;
+  $result = helper($1);
+}
+
+%typemap(out) std::string {
+  AsPythonString<ParaText::Encoding::UNKNOWN_BYTES, ParaText::Encoding::UNICODE_UTF8> helper;
+  $result = helper($1);
+}
+
+%typemap(out) ParaText::as_raw_bytes {
+  AsPythonString<ParaText::Encoding::UNKNOWN_BYTES, ParaText::Encoding::UNKNOWN_BYTES> helper;
+  $result = helper($1.val);
+}
+
+%typemap(out) ParaText::as_utf8 {
+  AsPythonString<ParaText::Encoding::UNKNOWN_BYTES, ParaText::Encoding::UNICODE_UTF8> helper;
+  $result = helper($1.val);
+}
+
+
+
 %{
 #include "python/numpy_helper.hpp"
+#include "python/python_input.hpp"
 %}
 

--- a/src/python/python.i
+++ b/src/python/python.i
@@ -45,15 +45,15 @@
 }
 
 %typemap(out) std::vector<int> {
-  $result = (PyObject*)::build_array<std::vector<int>>($1);
+  $result = (PyObject*)::build_array<ParaText::Encoding::UNKNOWN_BYTES, ParaText::Encoding::UNKNOWN_BYTES, std::vector<int>>($1);
 }
 
 %typemap(out) std::vector<double> {
-  $result = (PyObject*)::build_array<std::vector<double>>($1);
+  $result = (PyObject*)::build_array<ParaText::Encoding::UNKNOWN_BYTES, ParaText::Encoding::UNKNOWN_BYTES, std::vector<double>>($1);
 }
 
 %typemap(out) std::vector<size_t> {
-  $result = (PyObject*)::build_array<std::vector<size_t>>($1);
+  $result = (PyObject*)::build_array<ParaText::Encoding::UNKNOWN_BYTES, ParaText::Encoding::UNKNOWN_BYTES, std::vector<size_t>>($1);
 }
 
 %typemap(out) const std::vector<std::string> & {
@@ -63,11 +63,37 @@
 }
 
 %typemap(out) std::vector<std::string> {
-  $result = (PyObject*)::build_array<std::vector<std::string>>($1);
+  $result = (PyObject*)::build_array<ParaText::Encoding::UNKNOWN_BYTES, ParaText::Encoding::UNICODE_UTF8, std::vector<std::string>>($1);
+}
+
+%typemap(out) const std::vector<std::string> & {
+  { auto range = std::make_pair($1->begin(), $1->end());
+    $result = (PyObject*)::build_array_from_range<ParaText::Encoding::UNKNOWN_BYTES, ParaText::Encoding::UNKNOWN_BYTES>(range);
+  }
+}
+
+%typemap(out) const std::pair<std::vector<std::string>, ParaText::TagEncoding<UNICODE_UTF8, UNICODE_UTF8> > & {
+  { auto range = std::make_pair($1->begin(), $1->end());
+    $result = (PyObject*)::build_array_from_range<ParaText::Encoding::UNICODE_UTF8>>(range);
+  }
+}
+
+%typemap(out) const std::pair<std::vector<std::string>, ParaText::TagEncoding<UNNOWN_BYTES, UNICODE_UTF8> > & {
+  { auto range = std::make_pair($1->begin(), $1->end());
+    $result = (PyObject*)::build_array_from_range<ParaText::Encoding::UNICODE_UTF8>>(range);
+  }
+}
+
+%typemap(out) std::vector<std::string> {
+  $result = (PyObject*)::build_array<ParaText::Encoding::UNKNOWN_BYTES, ParaText::Encoding::UNICODE_UTF8, std::vector<std::string>>($1);
 }
 
 %typemap(out) ParaText::CSV::ColBasedPopulator {
   $result = (PyObject*)::build_populator<ParaText::CSV::ColBasedPopulator>($1);
+}
+
+%typemap(out) ParaText::CSV::StringVectorPopulator {
+  $result = (PyObject*)::build_populator<ParaText::CSV::StringVectorPopulator>($1);
 }
 
 %{

--- a/src/python/python_input.hpp
+++ b/src/python/python_input.hpp
@@ -1,0 +1,745 @@
+#ifndef WISEIO_PYTHON_INPUT_HPP
+#define WISEIO_PYTHON_INPUT_HPP
+
+#include <Python.h>
+
+#ifdef PARATEXT_DATE_TIME
+#include <datetime.h>
+#endif
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/arrayobject.h>
+#include <numpy/npy_math.h>
+#include <stdio.h>
+
+#include "processor.hpp"
+#include "util/unicode.hpp"
+#include "util/strings.hpp"
+
+namespace ParaText {
+  
+  class PyRefGuard {
+  public:
+    PyRefGuard() : object(NULL) {}
+    PyRefGuard(PyObject *obj) : object(obj) {}
+    
+    ~PyRefGuard() {
+      Py_XDECREF(object);
+      object = NULL;
+    }
+    
+    void steal(PyObject *other) {
+      Py_XDECREF(object);
+      object = other;
+    }
+    
+    void disown() {
+      object = NULL;
+    }
+    
+    void decref() {
+      Py_XDECREF(object);
+      object = NULL;
+    }
+    
+    PyObject *get() const {
+      return object;
+    }
+    
+  private:
+    PyObject *object;
+  };
+  
+  ParaText::IteratorElementType get_element_type(PyObject *obj) {
+    ParaText::IteratorElementType next_type;
+    if (PyString_Check(obj)) {
+      next_type = ParaText::IteratorElementType::STRING;
+    }
+    else if (PyUnicode_Check(obj)) {
+      next_type = ParaText::IteratorElementType::STRING;
+    }
+    else if (PyInt_Check(obj)) {
+      next_type = ParaText::IteratorElementType::LONG;
+    }
+    else if (PyLong_Check(obj)) {
+      next_type = ParaText::IteratorElementType::LONG;
+    }
+    else if (PyFloat_Check(obj)) {
+      next_type = ParaText::IteratorElementType::FLOAT;
+    }
+    else if (PyBool_Check(obj)) {
+      next_type = ParaText::IteratorElementType::BOOL;
+    }
+#ifdef PARATEXT_DATE_TIME
+    else if (PyDateTime_Check(obj)) {
+      next_type = ParaText::IteratorElementType::DATETIME;
+    }
+#endif
+    else {
+      throw std::string("cannot process type of element in sequence");
+    }
+    return next_type;
+  }
+  
+  template <class T>
+  typename std::enable_if<std::is_arithmetic<T>::value, float>::type
+  get_as_float(const T &t, size_t item_size) {
+    (void)item_size;
+    return (float)t;
+  }
+  
+  template <class T>
+  typename std::enable_if<std::is_arithmetic<T>::value, float>::type
+  get_as_long(const T &t, size_t item_size) {
+    (void)item_size;
+    return (long)t;
+  }
+  
+  
+  template <class T>
+  typename std::enable_if<std::is_arithmetic<T>::value, float>::type
+  get_as_bool(const T &t, size_t item_size) {
+    (void)item_size;
+    return (bool)t;
+  }
+  
+  bool get_as_bool(PyObject *obj, size_t item_size) {
+    (void)item_size;
+    return (bool)PyObject_IsTrue(obj);
+  }
+  
+  long get_as_long(PyObject *obj, size_t item_size) {
+    (void)item_size;
+    long retval = 0;
+    if (PyInt_Check(obj)) {
+      retval = PyInt_AsLong(obj);
+    }
+    else if (PyLong_Check(obj)) {
+      retval = PyLong_AsLong(obj);
+    }
+    else if (PyBool_Check(obj)) {
+      retval = PyObject_IsTrue(obj);
+    }
+    else if (PyFloat_Check(obj)) {
+      retval = (long)PyFloat_AsDouble(obj);
+    }
+    else if (PyString_Check(obj)) {
+      char *buf = PyString_AsString(obj);
+      size_t len = (size_t)PyString_Size(obj);
+      retval = ::fast_atoi<long>(buf, buf + len);
+    }
+    else if (PyUnicode_Check(obj)) {
+      PyRefGuard temp(PyUnicode_AsUTF8String(obj));
+      if (temp.get() == NULL) {
+        throw std::string("unable to convert unicode string to UTF-8");
+      }
+      Py_ssize_t size;
+      const char *buf = PyUnicode_AS_DATA(temp.get());
+      size = PyUnicode_GET_DATA_SIZE(temp.get());
+      retval = ::fast_atoi<long>(buf, buf + size);
+    }
+    else {
+      throw std::string("cannot handle item");
+    }
+    return retval;
+  }
+  
+  std::string get_as_string(const std::string &s, size_t) {
+    return s;
+  }
+  
+  template <class T>
+  typename std::enable_if<std::is_arithmetic<T>::value, std::string>::type
+  get_as_string(const T &val, size_t) {
+    std::ostringstream ostr;
+    ostr << val;
+    return ostr.str();
+  }
+  
+  std::string get_as_string(const npy_ucs4 *buf, size_t item_size) {
+    const npy_ucs4 *begin = buf;
+    const npy_ucs4 *end = buf + item_size / 4;
+    std::string retval;
+    WiseIO::convert_utf32_to_utf8(begin, end, std::back_inserter(retval), false);
+    return retval;
+  }
+  
+  std::string get_as_string(const char *buf, size_t item_size) {
+    const char *begin = buf;
+    const char *end = buf + item_size;
+    std::string retval(begin, end);
+    return retval;
+  }
+    
+  std::string get_as_string(PyObject *obj, size_t) {
+#if PY_MAJOR_VERSION >= 3
+    if (PyBytes_Check(obj)) {
+      char *buf = PyBytes_AsString(obj);
+      size_t len = (size_t)PyBytes_Size(obj);
+      return std::string(buf, buf + len);
+    }
+#else
+    if (PyString_Check(obj)) {
+      char *buf = PyString_AsString(obj);
+      size_t len = (size_t)PyString_Size(obj);
+      return std::string(buf, buf + len);
+    }
+#endif
+    else if (PyUnicode_Check(obj)) {
+      PyRefGuard temp(PyUnicode_AsUTF8String(obj));
+      if (temp.get() == NULL) {
+        throw std::string("unable to convert unicode string to UTF-8");
+      }
+      const char *buf = PyBytes_AsString(temp.get());
+      size_t size = (size_t)PyBytes_Size(temp.get());
+      std::string s(buf, buf + size);
+      return s;
+    }
+    else if (PyFloat_Check(obj)) {
+      std::ostringstream ostr;
+      double dval = PyFloat_AsDouble(obj);
+      ostr << dval;
+      return ostr.str();
+    }
+    else if (PyInt_Check(obj)) {
+      std::ostringstream ostr;
+      long ival = PyInt_AsLong(obj);
+      ostr << ival;
+      return ostr.str();
+    }
+    else if (PyLong_Check(obj)) {
+      std::ostringstream ostr;
+      long ival = PyLong_AsLong(obj);
+      ostr << ival;
+      return ostr.str();
+    }
+    else if (PyBool_Check(obj)) {
+      std::ostringstream ostr;
+      bool bval = PyObject_IsTrue(obj);
+      ostr << bval;
+      return ostr.str();
+    }
+    else {
+      PyRefGuard guard(PyObject_Str(obj));
+      char *buf = PyString_AsString(guard.get());
+      size_t len = (size_t)PyString_Size(guard.get());
+      return std::string(buf, buf + len);
+    }
+  }
+  
+  double get_as_float(const npy_ucs4 *buf, size_t item_size) {
+    (void)buf;
+    std::string s(get_as_string(buf, item_size));
+    return ::bsd_strtod(s.begin(), s.end());
+  }
+  
+  double get_as_float(const char *buf, size_t item_size) {
+    (void)buf;
+    std::string s(get_as_string(buf, item_size));
+    return ::bsd_strtod(s.begin(), s.end());
+  }
+  
+  long get_as_long(const npy_ucs4 *buf, size_t item_size) {
+    (void)buf;
+    std::string s(get_as_string(buf, item_size));
+    return ::fast_atoi<long>(s.begin(), s.end());
+  }
+  
+  long get_as_long(const char *buf, size_t item_size) {
+    (void)buf;
+    std::string s(get_as_string(buf, item_size));
+    return ::fast_atoi<long>(s.begin(), s.end());
+  }
+  
+  long get_as_bool(npy_ucs4 *buf, size_t item_size) {
+    (void)buf;
+    (void)item_size;
+    long retval = 0;
+    throw std::string("cannot convert UCS-4 to a float");
+    return retval;
+  }
+  
+  long get_as_bool(char *buf, size_t item_size) {
+    (void)buf;
+    (void)item_size;
+    long retval = 0;
+    throw std::string("cannot convert UTF-8 to a float");
+    return retval;
+  }
+
+  double get_as_float(PyObject *obj, size_t item_size) {
+    (void)item_size;
+    double retval = 0;
+    if (PyFloat_Check(obj)) {
+      retval = PyFloat_AsDouble(obj);
+    }
+    else if (PyInt_Check(obj)) {
+      retval = PyInt_AsLong(obj);
+    }
+    else if (PyLong_Check(obj)) {
+      retval = PyLong_AsLong(obj);
+    }
+    else if (PyBool_Check(obj)) {
+      retval = PyObject_IsTrue(obj);
+    }
+    else if (PyString_Check(obj)) {
+      char *buf = PyString_AsString(obj);
+      size_t len = (size_t)PyString_Size(obj);
+      retval = ::bsd_strtod(buf, buf + len);
+    }
+    else if (PyUnicode_Check(obj)) {
+      PyRefGuard temp(PyUnicode_AsUTF8String(obj));
+      if (temp.get() == NULL) {
+        throw std::string("unable to convert unicode string to UTF-8");
+      }
+      char *buf = PyString_AsString(temp.get());
+      auto size = PyUnicode_GET_DATA_SIZE(temp.get());
+      retval = ::bsd_strtod(buf, buf + size);
+    }
+    else {
+      throw std::string("cannot handle item");
+    }
+    return retval;
+  }
+  
+  ParaText::IteratorElementType get_element_type(char *buf) {
+    (void)buf;
+    return ParaText::IteratorElementType::STRING;
+  }
+  
+  ParaText::IteratorElementType get_element_type(npy_ucs4 *buf) {
+    (void)buf;
+    return ParaText::IteratorElementType::STRING;
+  }
+  
+  template <class T>
+  typename std::enable_if<std::is_floating_point<T>::value, ParaText::IteratorElementType>::type
+  get_element_type(T) {
+    return ParaText::IteratorElementType::FLOAT;
+  }
+  
+  template <class T>
+  typename std::enable_if<std::is_integral<T>::value && !std::is_same<T, bool>::value, ParaText::IteratorElementType>::type
+    get_element_type(T) {
+    return ParaText::IteratorElementType::LONG;
+  }
+  
+  template <class T>
+  typename std::enable_if<std::is_integral<T>::value && std::is_same<T, bool>::value, ParaText::IteratorElementType>::type
+    get_element_type(T) {
+    return ParaText::IteratorElementType::BOOL;
+  }
+
+#ifdef PARATEXT_DATE_TIME
+
+  template <class T>
+  typename std::enable_if<std::is_arithmetic<T>::value, boost::posix_time::ptime>::type
+  get_as_datetime(T, size_t) {
+    throw std::logic_error("cannot convert item to datetime");
+  }
+
+  boost::posix_time::ptime get_as_datetime(const char *buf, size_t item_size) {
+    std::string s(get_as_string(buf, item_size));
+    return boost::posix_time::time_from_string(s);
+  }
+
+  boost::posix_time::ptime get_as_datetime(const npy_ucs4 *buf, size_t item_size) {
+    std::string s(get_as_string(buf, item_size));
+    return boost::posix_time::time_from_string(s);
+  }
+
+  boost::posix_time::ptime get_as_datetime(PyObject *obj, size_t item_size) {
+    (void)item_size;
+    if (PyDateTime_Check(obj)) {
+      int year = PyDateTime_GET_YEAR(obj);
+      int month = PyDateTime_GET_MONTH(obj);
+      int day = PyDateTime_GET_DAY(obj);
+      int hour = PyDateTime_DATE_GET_HOUR(obj);
+      int mins = PyDateTime_DATE_GET_MINUTE(obj);
+      int secs = PyDateTime_DATE_GET_SECOND(obj);
+      int ms = PyDateTime_DATE_GET_MICROSECOND(obj);
+      boost::posix_time::ptime t(boost::gregorian::date(year, month, day),
+                                 boost::posix_time::time_duration(hour, mins, secs, ms));
+      return t;
+    }
+    else if (PyUnicode_Check(obj)) {
+      Py_ssize_t size;
+      PyRefGuard temp(PyUnicode_AsUTF8String(obj));
+      const char *buf = PyUnicode_AS_DATA(temp.get());
+      size = PyUnicode_GET_DATA_SIZE(temp.get());
+      return get_as_datetime(buf, size);
+    }
+    else if (PyString_Check(obj)) {
+      char *buf = PyString_AsString(obj);
+      size_t len = (size_t)PyString_Size(obj);
+      return get_as_datetime(buf, len);
+    }
+    else {
+      throw std::logic_error("cannot convert item to string");
+    }
+  }
+
+#endif
+  
+  class PythonSequenceAdvancer {
+  public:
+    PythonSequenceAdvancer(PyObject *sequence) : idx_(0), size_(0), sequence_(sequence) {
+      size_ = PySequence_Size(sequence);
+      Py_XINCREF((PyObject*)sequence);
+    }
+    
+    ~PythonSequenceAdvancer() {
+      Py_XDECREF((PyObject*)sequence_);
+      sequence_ = NULL;
+    }
+    
+    bool has_next() const {
+      return idx_ < size_;
+    }
+    
+    void advance() {
+      PyObject *next_item = NULL;
+      if (idx_ < size_) {
+        next_item = PySequence_GetItem(sequence_, idx_);
+        guard_.steal(next_item);
+      }
+      else {
+        guard_.decref();
+      }
+      idx_++;
+    }
+    
+    PyObject *current() const {
+      return guard_.get();
+    }
+    
+    size_t get_item_size() const {
+      return sizeof(PyObject*);
+    }
+    
+    size_t size() const {
+      return size_;
+    }
+    
+  private:
+    Py_ssize_t idx_;
+    Py_ssize_t size_;
+    PyObject *sequence_;
+    PyRefGuard guard_;
+  };
+  
+  class PythonIteratorAdvancer {
+  public:
+    PythonIteratorAdvancer(PyObject *sequence) : size_(0), sequence_(sequence) {
+      size_ = std::numeric_limits<size_t>::max();
+      PyObject *next_item = PyIter_Next(sequence_);
+      next_guard_.steal(next_item);
+      Py_XINCREF((PyObject*)sequence);
+    }
+    
+    ~PythonIteratorAdvancer() {
+      Py_XDECREF((PyObject*)sequence_);
+      sequence_ = NULL;
+    }
+    
+    bool has_next() const {
+      return next_guard_.get() != NULL;
+    }
+    
+    void advance() {
+      PyObject *item = PyIter_Next(sequence_);
+      PyObject *new_cur = next_guard_.get();
+      next_guard_.disown();
+      next_guard_.steal(item);
+      cur_guard_.steal(new_cur);
+    }
+    
+    PyObject *current() const {
+      return cur_guard_.get();
+    }
+    
+    size_t get_item_size() const {
+      return sizeof(PyObject*);
+    }
+    
+    size_t size() const {
+      return std::numeric_limits<size_t>::max();
+    }
+    
+    Py_ssize_t size_;
+    PyObject *sequence_;
+    PyRefGuard next_guard_;
+    PyRefGuard cur_guard_;
+  };
+  
+  template <class npy_prim>
+  class NumPyAdvancer {
+  public:
+    
+    NumPyAdvancer() : idx_(0), size_(0), sequence_(NULL) {}
+    
+    NumPyAdvancer(PyArrayObject *sequence) : idx_(0), size_(0), sequence_(sequence) {
+      if (PyArray_NDIM(sequence) != 1) {
+        throw std::string("a NumPy array must be 1-dimensional. use reshape");
+      }
+      size_ = PyArray_DIM(sequence, 0);
+      item_ = (npy_prim)0;
+      item_size_ = PyArray_ITEMSIZE(sequence_);
+      Py_XINCREF((PyObject*)sequence);
+    }
+    
+    ~NumPyAdvancer() {
+      Py_XDECREF((PyObject*)sequence_);
+      sequence_ = NULL;
+    }
+    
+    inline bool has_next() const {
+      return idx_ < size_;
+    }
+    
+    inline void advance() {
+      advance_impl<npy_prim>();
+    }
+
+    template <class Prim>
+    inline typename std::enable_if<std::is_same<Prim, npy_ucs4*>::value
+                                   || std::is_same<Prim, char*>::value, void>::type advance_impl() {
+      item_ = (npy_prim)PyArray_GETPTR1(sequence_, idx_);
+      idx_++;      
+    }
+
+    template <class Prim>
+    inline typename std::enable_if<std::is_arithmetic<Prim>::value, void>::type advance_impl() {
+      item_ = *(npy_prim*)PyArray_GETPTR1(sequence_, idx_);
+      idx_++;
+    }
+
+    template <class Prim>
+    inline typename std::enable_if<std::is_same<Prim, PyObject*>::value
+                                   || std::is_same<Prim, PyObject*>::value, void>::type advance_impl() {
+      /* Returns PyObject** */
+      item_ = *(npy_prim*)PyArray_GETPTR1(sequence_, idx_);
+      idx_++;      
+    }
+    
+    inline npy_prim current() const {
+      return item_;
+    }
+    
+    inline size_t get_item_size() const {
+      return item_size_;
+    }
+    
+    inline size_t size() const {
+      return size_;
+    }
+    
+    npy_intp idx_;
+    npy_intp size_;
+    npy_intp item_size_;
+    PyArrayObject *sequence_;
+    PyRefGuard guard_;
+    npy_prim item_;
+  };
+
+
+template <class Advancer>
+class PythonIteratorProcessor : public ParaText::IteratorProcessor {
+public:
+  PythonIteratorProcessor() {}
+
+  PythonIteratorProcessor(std::shared_ptr<Advancer> advancer) : advancer(advancer) {}
+
+  virtual ~PythonIteratorProcessor() {}
+
+  virtual ParaText::IteratorElementType get_type() const {
+    return get_element_type(advancer->current());
+  }
+
+  virtual std::string get_string() const {
+    return get_as_string(advancer->current(), advancer->get_item_size());
+  }
+
+  virtual double get_float() const {
+    return get_as_float(advancer->current(), advancer->get_item_size());
+  }
+
+  virtual long get_long() const {
+    return get_as_long(advancer->current(), advancer->get_item_size());
+  }
+
+  virtual bool get_bool() const {
+    return get_as_bool(advancer->current(), advancer->get_item_size());
+  }
+
+#ifdef PARATEXT_DATE_TIME
+  virtual boost::posix_time::ptime get_datetime() const {
+    return get_as_datetime(advancer->current(), advancer->get_item_size());
+  }
+#endif
+
+  virtual void advance() {
+    advancer->advance();
+  }
+
+  virtual size_t size() const {
+    return advancer->size();
+  }
+
+  virtual bool has_next() const {
+    return advancer->has_next();
+  }
+
+private:
+  PyObject *obj;
+  std::shared_ptr<Advancer> advancer;
+};
+
+std::shared_ptr<ParaText::IteratorProcessor> get_python_iterator_processor(PyObject *object) {
+  std::shared_ptr<ParaText::IteratorProcessor> retval;
+  PyObject *iter = NULL;
+  if (PyArray_Check(object)) {
+    PyArrayObject *array = (PyArrayObject*)object;
+    npy_int ndim = PyArray_NDIM(array);
+    if (ndim != 1) {
+      throw std::logic_error("can only process 1D arrays");
+      retval.reset();
+    }
+    switch (PyArray_TYPE(array)) {
+    case NPY_OBJECT:
+      {
+        std::shared_ptr<NumPyAdvancer<PyObject*> > advancer(std::make_shared<NumPyAdvancer<PyObject*> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<PyObject*> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+    case NPY_STRING:
+      {
+        std::shared_ptr<NumPyAdvancer<char*> > advancer(std::make_shared<NumPyAdvancer<char*> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<char*> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+    case NPY_UNICODE:
+      {
+        std::shared_ptr<NumPyAdvancer<npy_ucs4*> > advancer(std::make_shared<NumPyAdvancer<npy_ucs4*> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<npy_ucs4*> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+    case NPY_FLOAT:
+      {
+        std::shared_ptr<NumPyAdvancer<npy_float> > advancer(std::make_shared<NumPyAdvancer<npy_float> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<npy_float> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+    case NPY_DOUBLE:
+      {
+        std::shared_ptr<NumPyAdvancer<npy_double> > advancer(std::make_shared<NumPyAdvancer<npy_double> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<npy_double> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+    case NPY_UINT8:
+      {
+        std::shared_ptr<NumPyAdvancer<npy_uint8> > advancer(std::make_shared<NumPyAdvancer<npy_uint8> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<npy_uint8> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+    case NPY_INT8:
+      {
+        std::shared_ptr<NumPyAdvancer<npy_int8> > advancer(std::make_shared<NumPyAdvancer<npy_int8> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<npy_int8> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+#ifdef NPY_UINT16
+    case NPY_UINT16:
+      {
+        std::shared_ptr<NumPyAdvancer<npy_uint16> > advancer(std::make_shared<NumPyAdvancer<npy_uint16> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<npy_uint16> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+#endif
+#ifdef NPY_INT16
+    case NPY_INT16:
+      {
+        std::shared_ptr<NumPyAdvancer<npy_int16> > advancer(std::make_shared<NumPyAdvancer<npy_int16> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<npy_int16> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+#endif
+#ifdef NPY_UINT32
+    case NPY_UINT32:
+      {
+        std::shared_ptr<NumPyAdvancer<npy_uint32> > advancer(std::make_shared<NumPyAdvancer<npy_uint32> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<npy_uint32> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+#endif
+#ifdef NPY_INT32
+    case NPY_INT32:
+      {
+        std::shared_ptr<NumPyAdvancer<npy_int32> > advancer(std::make_shared<NumPyAdvancer<npy_int32> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<npy_int32> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+#endif
+    case NPY_UINT64:
+      {
+        std::shared_ptr<NumPyAdvancer<npy_uint64> > advancer(std::make_shared<NumPyAdvancer<npy_uint64> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<npy_uint64> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+    case NPY_INT64:
+      {
+        std::shared_ptr<NumPyAdvancer<npy_int64> > advancer(std::make_shared<NumPyAdvancer<npy_int64> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<npy_int64> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+#ifdef NPY_BOOL
+    case NPY_BOOL:
+      {
+        std::shared_ptr<NumPyAdvancer<npy_bool> > advancer(std::make_shared<NumPyAdvancer<npy_bool> >(array));
+        auto ptr = std::make_shared<PythonIteratorProcessor<NumPyAdvancer<npy_bool> > >(advancer);
+        retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+      }
+      break;
+#endif
+    default:
+      throw std::logic_error("cannot process dtype");
+      retval = NULL;
+    }
+  }
+  else if (PySequence_Check(object)) {
+    std::shared_ptr<PythonSequenceAdvancer> advancer(std::make_shared<PythonSequenceAdvancer>(object));
+    auto ptr = std::make_shared<PythonIteratorProcessor<PythonSequenceAdvancer> >(advancer);
+    retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+  }
+  else if (PyIter_Check(object)) {
+    std::shared_ptr<PythonIteratorAdvancer> advancer(std::make_shared<PythonIteratorAdvancer>(object));
+    auto ptr = std::make_shared<PythonIteratorProcessor<PythonIteratorAdvancer> >(advancer);
+    retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+  }
+  else if ((iter = PyObject_GetIter(object)) != NULL) {
+    PyRefGuard guard(iter);
+    std::shared_ptr<PythonIteratorAdvancer> advancer(std::make_shared<PythonIteratorAdvancer>(iter));
+    auto ptr = std::make_shared<PythonIteratorProcessor<PythonIteratorAdvancer> >(advancer);
+    retval = std::static_pointer_cast<ParaText::IteratorProcessor>(ptr);
+  }
+  else {
+    throw std::logic_error("cannot process object passed - not a sequence, an iterator, an iterable, or an array");
+    retval.reset();
+  }
+  return retval;
+}
+}
+#endif

--- a/src/util/safe_string_output.hpp
+++ b/src/util/safe_string_output.hpp
@@ -1,0 +1,245 @@
+/*
+
+    ParaText: parallel text reading
+    Copyright (C) 2016. wise.io, Inc.
+
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+ */
+
+/*
+  Coder: Damian Eads.
+ */
+
+#ifndef SAFE_STRING_OUTPUT_HPP
+#define SAFE_STRING_OUTPUT_HPP
+
+#include <array>
+#include <sstream>
+#include <iomanip>
+
+namespace WiseIO {
+
+  typedef enum {NO_ESCAPE, ESCAPE, CONTINUATION, LEAD2, LEAD3, LEAD4, POTENTIAL_SURROGATE} SafeCharState;
+
+  class SafeStringOutput {
+  public:
+    SafeStringOutput() : double_quote_output_(false) {
+      should_escape_.fill(NO_ESCAPE);
+      should_escape_['\\'] = SafeCharState::ESCAPE;
+    }
+
+    ParaText::as_utf8 to_utf8_string(const std::string &input) {
+      ParaText::as_utf8 output;
+      output.val = output_string(input.begin(), input.end());
+      return output;
+    }
+
+    ParaText::as_raw_bytes to_raw_string(const std::string &input) {
+      ParaText::as_raw_bytes output;
+      output.val = output_string(input.begin(), input.end());
+      return output;
+    }
+
+    template <class Iterator>
+    std::string output_string(Iterator begin, Iterator end) {
+      /* FIXME: Support filtering of illegal surrogates in UTF8 sequences. */
+      std::ostringstream ostr;
+      size_t bytes_in_sequence = 0;
+      //bool surrogate = false;
+      if (double_quote_output_) {
+        ostr << '"';
+      }
+      std::vector<bool> escaped(std::distance(begin, end), false);
+      size_t k = 0;
+      for (Iterator it = begin; it != end; it++, k++) {
+        unsigned char c = (unsigned char)*it;
+        bool escape_it = should_escape_[c] == ESCAPE;
+        if (bytes_in_sequence > 0) { /* If a UTF8 sequence was started, only escape the byte if its not a continuation. */
+          escape_it = should_escape_[c] != CONTINUATION;
+          bytes_in_sequence--;
+        }
+        else if (!escape_it && bytes_in_sequence == 0) { /* If a UTF8 sequence is not progress, check higher order bits. */
+          switch (should_escape_[c]) {
+          case LEAD4:
+            bytes_in_sequence = 3;
+            break;
+          case POTENTIAL_SURROGATE:
+            /*bytes_in_sequence = 2;
+              surrogate = true;*/
+            break;
+          case LEAD3:
+            bytes_in_sequence = 2;
+            break;
+          case LEAD2:
+            bytes_in_sequence = 1;
+            break;
+          case NO_ESCAPE:
+            break;
+          case ESCAPE: /* Explicit escape. */
+          case CONTINUATION: /* An invalid continuation byte, escape it. */
+            escape_it = true;
+            break;
+          }
+        }
+        escaped[k] = escape_it;
+      }
+      k = 0;
+      for (Iterator it = begin; it != end; it++, k++) {
+        unsigned char c = (unsigned char)*it;
+        if (escaped[k]) {
+          ostr << '\\';
+          switch (c) {
+          case '\b':
+            ostr << 'b';
+            break;
+          case '\v':
+            ostr << 'v';
+            break;
+          case '\n':
+            ostr << 'n';
+            break;
+          case '\r':
+            ostr << 'r';
+            break;
+          case '\t':
+            ostr << 't';
+            break;
+          case '\\':
+            ostr << '\\';
+            break;
+          case '\"':
+            ostr << '\"';
+            break;
+          case '\'':
+            ostr << '\'';
+            break;
+          default:
+            ostr << 'x';
+            ostr << to_hex(c >> 4);
+            ostr << to_hex(c & 0x0F);
+            break;
+          }
+        }
+        else {
+          ostr.put(*it);
+        }
+      }
+      if (double_quote_output_) {
+        ostr << '"';
+      }
+      return ostr.str();
+    }
+
+    void escape_newlines(bool b) {
+      SafeCharState st = b ? SafeCharState::ESCAPE : SafeCharState::NO_ESCAPE;
+      should_escape_['\n'] = st;
+    }
+
+    void escape_whitespace(bool b) {
+      SafeCharState st = b ? SafeCharState::ESCAPE : SafeCharState::NO_ESCAPE;
+      should_escape_['\n'] = st;
+      should_escape_['\r'] = st;
+      should_escape_['\v'] = st;
+      should_escape_['\f'] = st;
+      should_escape_['\b'] = st;
+    }
+
+    void escape_special(bool b) {
+      SafeCharState st = b ? SafeCharState::ESCAPE : SafeCharState::NO_ESCAPE;
+      should_escape_['\''] = st;
+      should_escape_['\"'] = st;
+      should_escape_['\\'] = st;
+    }
+
+    void escape_delim(bool b) {
+      SafeCharState st = b ? SafeCharState::ESCAPE : SafeCharState::NO_ESCAPE;
+      should_escape_[','] = st;
+      escape_special(true);
+    }
+
+    void escape_comments(bool b) {
+      SafeCharState st = b ? SafeCharState::ESCAPE : SafeCharState::NO_ESCAPE;
+      should_escape_['%'] = st;
+      escape_special(true);
+    }
+
+    void escape_nonprintables(bool b) {
+      SafeCharState st = b ? SafeCharState::ESCAPE : SafeCharState::NO_ESCAPE;
+      for (unsigned char c = 0; c < ' '; c++) {
+        should_escape_[c] = st;
+      }
+    }
+
+    void escape_nonascii(bool b) {
+      SafeCharState st = b ? SafeCharState::ESCAPE : SafeCharState::NO_ESCAPE;
+      for (size_t c = 0x7F; c <= 0xFF; c++) {
+        should_escape_[c] = st;
+      }
+    }
+
+    void escape_nonutf8(bool b) {
+      const SafeCharState outside = b ? SafeCharState::ESCAPE : SafeCharState::NO_ESCAPE;
+      const SafeCharState cont = b ? SafeCharState::CONTINUATION : SafeCharState::NO_ESCAPE;
+      const SafeCharState lead2 = b ? SafeCharState::LEAD2 : SafeCharState::NO_ESCAPE;
+      const SafeCharState lead3 = b ? SafeCharState::LEAD3 : SafeCharState::NO_ESCAPE;
+      const SafeCharState lead4 = b ? SafeCharState::LEAD4 : SafeCharState::NO_ESCAPE;
+      //const SafeCharState surrogate = b ? SafeCharState::POTENTIAL_SURROGATE : SafeCharState::NO_ESCAPE;
+      for (size_t c = 0x80; c <= 0xBF; c++) {
+        should_escape_[c] = cont;
+      }
+      for (size_t c = 0xC0; c <= 0xDF; c++) {
+        should_escape_[c] = lead2;
+      }
+      for (size_t c = 0xE0; c <= 0xEF; c++) {
+        should_escape_[c] = lead3;
+      }
+      for (size_t c = 0xF0; c <= 0xF7; c++) {
+        should_escape_[c] = lead4;
+      }
+      for (size_t c = 0xF8; c <= 0xFF; c++) {
+        should_escape_[c] = outside;
+      }
+      //should_escape_[0xED] = surrogate;
+    }
+
+    void double_quote_output(bool b) {
+      if (b) {
+        should_escape_['\"'] = SafeCharState::ESCAPE;
+      }
+      double_quote_output_ = b;
+    }
+
+  private:
+    inline char to_hex(int v) {
+      if (v >= 0 && v < 10) {
+        return '0' + v;
+      }
+      else if (v >= 10 && v < 16) {
+        return 'a' + (v-10);
+      }
+      else {
+        throw std::logic_error("invalid range for hex character");
+      }
+    }
+    
+  private:
+    std::array<SafeCharState, 256> should_escape_;
+    bool double_quote_output_;
+  };
+}
+#endif

--- a/src/util/strings.hpp
+++ b/src/util/strings.hpp
@@ -112,12 +112,7 @@
     Takes a UTF-8 sequence and returns a string that's double quoted if it is required to parse
     it as a contiguous entity that is not-altered (e.g. space-delimited strings).
 
-    If the string contains a comment character (%) or a null-terminator (0), it will be
-    quoted.
-
     Non-space whitespace characters will be backslash-escaped with \n, \t, \v, \r, \b, \f.
-
-    Null-terminators are quoted with \0.
 
     If ``mandatory_quoting`` is true, the string will automatically be double quoted.
    */
@@ -205,9 +200,6 @@
     where *begin is some quote character (e.g. '\"'). It returns an iterator
     pointing to the ending unprocessed character (one after the quote
     character).
-
-    Null-terminator escape sequences \0 are translated into spaces for
-    security reasons.
    */
   template <class Iterator, class OutputIterator>
   inline Iterator parse_quoted_string(Iterator begin, Iterator end, OutputIterator out, const char quote_char) {
@@ -281,7 +273,7 @@
 	      }
 	      break;
 	    case '0':
-	      *(out++) = ' ';
+	      *(out++) = '\0';
 	      break;
 	    default:
 	      *(out++) = *begin;
@@ -374,7 +366,7 @@
 	      }
 	      break;
 	    case '0':
-	      *(out++) = ' ';
+	      *(out++) = '\0';
 	      break;
 	    default:
 	      *(out++) = *begin;
@@ -388,6 +380,15 @@
 	begin++;
       }
     return begin;
+  }
+
+  template <class Iterator>
+  void convert_null_to_space(Iterator begin, Iterator end) {
+    for (Iterator it = begin; it != end; it++) {
+      if (*it == '\0') {
+        *it = ' ';
+      }
+    }
   }
 
   /*

--- a/src/util/strings.hpp
+++ b/src/util/strings.hpp
@@ -31,6 +31,9 @@
 #include <string>
 #include <memory>
 #include <sstream>
+#include <limits>
+#include <random>
+#include "unicode.hpp"
 
   template <class T>
   struct content_hash {};
@@ -344,6 +347,9 @@
 	      break;
 	    case 'v':
 	      *(out++) = '\v';
+	      break;
+	    case 'e':
+	      *(out++) = '\\';
 	      break;
 	    case 'x':
 	      {

--- a/src/util/strings.hpp
+++ b/src/util/strings.hpp
@@ -70,8 +70,8 @@
   };
 
   inline long get_decimal_from_ascii_hex(char x) {
-    char y = tolower(x);
-    return (y >= 'a') ? (y - 'a') + 10 : (y - '0');
+    //char y = tolower(x);
+    return (x >> 6) * 9 + (0x0F & x);
   }
 
   /*
@@ -255,41 +255,55 @@
 	    case 'x':
 	      {
 		int sumv = 0;
-		int multipliers[] = {0x10, 0x01};
 		for (int i = 0; i < 2; i++) {
-		  if (begin + 1 != end) {
+		  if (begin + 1 != end && isxdigit(*(begin + 1))) {
 		    begin++;
 		    int digit = *begin;
-		    if (isxdigit(digit)) {
-		      sumv += multipliers[i] * get_decimal_from_ascii_hex(digit);
-		    }
+            sumv = sumv * 16 + get_decimal_from_ascii_hex(digit);
 		  }
+          else {
+            std::ostringstream ostr;
+            ostr << "literal \\xYY takes 2 hex digits, " << (i+1) << " given.";
+            throw std::logic_error(ostr.str());
+          }
 		}
 		*(out++) = (unsigned char)sumv;
 	      }
 	      break;
-	    case 'u': /* handle the rare case where a UCS-2 literal is provided
-		         encoded as a sequence of 7-bit ASCII characters, e.g.
-		         the string "\\u7c7b".
-
-			 Note: WiseML does NOT support reading files
-			 encoded in UCS-2/UTF-16, only ASCII and
-			 UTF-8. This allows UCS-2 literals in
-			 non-UCS-2 ASCII files.
-                       */
+	    case 'u':
 	      {
-		int sumv = 0;
-		int multipliers[] = {0x1000, 0x0100, 0x0010, 0x0001};
+		long sumv = 0;
 		for (int i = 0; i < 4; i++) {
-		  if (begin + 1 != end) {
+		  if (begin + 1 != end && isxdigit(*(begin + 1))) {
 		    begin++;
-		    int digit = *begin;
-		    if (isxdigit(digit)) {
-		      sumv += multipliers[i] * get_decimal_from_ascii_hex(digit);
-		    }
+		    int digit = get_decimal_from_ascii_hex(*begin);
+            sumv = sumv * 16 + digit;
 		  }
+          else {
+            std::ostringstream ostr;
+            ostr << "unicode literal \\uyyyy takes 4 hex digits for codepoint.";
+            throw std::logic_error(ostr.str());
+          }
 		}
-		ucs2_to_utf8(sumv, out);
+        WiseIO::convert_utf32_to_utf8(&sumv, &sumv + 1, out);
+	      }
+	      break;
+	    case 'U':
+	      {
+		long sumv = 0;
+		for (int i = 0; i < 8; i++) {
+		  if (begin + 1 != end && isxdigit(*(begin + 1))) {
+		    begin++;
+		    int digit = get_decimal_from_ascii_hex(*begin);
+            sumv = sumv * 16 + digit;
+		  }
+          else {
+            std::ostringstream ostr;
+            ostr << "unicode literal \\Uyyyyyyyy takes 8 hex digits for codepoint.";
+            throw std::logic_error(ostr.str());
+          }
+		}
+        WiseIO::convert_utf32_to_utf8(&sumv, &sumv + 1, out);
 	      }
 	      break;
 	    case '0':
@@ -354,41 +368,55 @@
 	    case 'x':
 	      {
 		int sumv = 0;
-		int multipliers[] = {0x10, 0x01};
 		for (int i = 0; i < 2; i++) {
-		  if (begin + 1 != end) {
+		  if (begin + 1 != end && isxdigit(*(begin + 1))) {
 		    begin++;
 		    int digit = *begin;
-		    if (isxdigit(digit)) {
-		      sumv += multipliers[i] * get_decimal_from_ascii_hex(digit);
-		    }
+            sumv = sumv * 16 + get_decimal_from_ascii_hex(digit);
 		  }
+          else {
+            std::ostringstream ostr;
+            ostr << "hex literal \\xYY takes 2 hex digits.";
+            throw std::logic_error(ostr.str());
+          }
 		}
 		*(out++) = (unsigned char)sumv;
 	      }
 	      break;
-	    case 'u': /* handle the rare case where a UCS-2 literal is provided
-		         encoded as a sequence of 7-bit ASCII characters, e.g.
-		         the string "\\u7c7b".
-
-			 Note: WiseML does NOT support reading files
-			 encoded in UCS-2/UTF-16, only ASCII and
-			 UTF-8. This allows UCS-2 literals in
-			 non-UCS-2 ASCII files.
-                       */
+	    case 'u':
 	      {
-		int sumv = 0;
-		int multipliers[] = {0x1000, 0x0100, 0x0010, 0x0001};
+		long sumv = 0;
 		for (int i = 0; i < 4; i++) {
-		  if (begin + 1 != end) {
+		  if (begin + 1 != end && isxdigit(*(begin + 1))) {
 		    begin++;
-		    int digit = *begin;
-		    if (isxdigit(digit)) {
-		      sumv += multipliers[i] * get_decimal_from_ascii_hex(digit);
-		    }
+		    int digit = get_decimal_from_ascii_hex(*begin);
+            sumv = sumv * 16 + digit;
 		  }
+          else {
+            std::ostringstream ostr;
+            ostr << "unicode literal \\uyyyy takes 4 hex digits for codepoint.";
+            throw std::logic_error(ostr.str());
+          }
 		}
-		ucs2_to_utf8(sumv, out);
+        WiseIO::convert_utf32_to_utf8(&sumv, &sumv + 1, out);
+	      }
+	      break;
+	    case 'U':
+	      {
+		long sumv = 0;
+		for (int i = 0; i < 8; i++) {
+		  if (begin + 1 != end && isxdigit(*(begin + 1))) {
+		    begin++;
+		    int digit = get_decimal_from_ascii_hex(*begin);
+            sumv = sumv * 16 + digit;
+		  }
+          else {
+            std::ostringstream ostr;
+            ostr << "unicode literal \\Uyyyyyyyy takes 8 hex digits for codepoint.";
+            throw std::logic_error(ostr.str());
+          }
+		}
+        WiseIO::convert_utf32_to_utf8(&sumv, &sumv + 1, out);
 	      }
 	      break;
 	    case '0':

--- a/src/util/unicode.hpp
+++ b/src/util/unicode.hpp
@@ -1,0 +1,66 @@
+#ifndef WISEIO_UNICODE_HPP
+#define WISEIO_UNICODE_HPP
+
+#define UNI_REPLACEMENT_CHAR (WUTF32)0x0000FFFD
+#define UNI_MAX_BMP (WUTF32)0x0000FFFF
+#define UNI_MAX_UTF16 (WUTF32)0x0010FFFF
+#define UNI_MAX_UTF32 (WUTF32)0x7FFFFFFF
+#define UNI_MAX_LEGAL_UTF32 (WUTF32)0x0010FFFF
+
+#define UNI_SUR_HIGH_START  (WUTF32)0xD800
+#define UNI_SUR_HIGH_END    (WUTF32)0xDBFF
+#define UNI_SUR_LOW_START   (WUTF32)0xDC00
+#define UNI_SUR_LOW_END     (WUTF32)0xDFFF
+
+namespace WiseIO {
+
+  template <class InputIterator, class OutputIterator>
+  int convert_utf32_to_utf8(InputIterator start,
+                            InputIterator end,
+                            OutputIterator out,
+                            bool strict = false) {
+
+    typedef unsigned long WUTF32;
+    typedef unsigned char WUTF8;
+    static const WUTF8 firstByteMark[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
+    int result = 0;
+    for (InputIterator it = start; it != end; it++) {
+      WUTF32 ch = *it;
+      unsigned short bytesToWrite = 0;
+      const WUTF32 byteMask = 0xBF;
+      const WUTF32 byteMark = 0x80;
+      if (strict) {
+        /* UTF-16 surrogate values are illegal in UTF-32 */
+        if (ch >= UNI_SUR_HIGH_START && ch <= UNI_SUR_LOW_END) {
+          result = 1;
+          break;
+        }
+      }
+      /*
+       * Figure out how many bytes the result will require. Turn any
+       * illegally large UTF32 things (> Plane 17) into replacement chars.
+       */
+      if (ch < (WUTF32)0x80) {	     bytesToWrite = 1;
+      } else if (ch < (WUTF32)0x800) {     bytesToWrite = 2;
+      } else if (ch < (WUTF32)0x10000) {   bytesToWrite = 3;
+      } else if (ch <= UNI_MAX_LEGAL_UTF32) {  bytesToWrite = 4;
+      } else {			    bytesToWrite = 3;
+        ch = UNI_REPLACEMENT_CHAR;
+        result = 1;
+        break;
+      }
+      unsigned char buf[4];
+      switch (bytesToWrite) { /* note: everything falls through. */
+      case 4: buf[3] = (WUTF8)((ch | byteMark) & byteMask); ch >>= 6;
+      case 3: buf[2] = (WUTF8)((ch | byteMark) & byteMask); ch >>= 6;
+      case 2: buf[1] = (WUTF8)((ch | byteMark) & byteMask); ch >>= 6;
+      case 1: buf[0] = (WUTF8) (ch | firstByteMark[bytesToWrite]);
+      }
+      for(int i = 0; i < bytesToWrite; i++) {
+        *(out++) = buf[i];
+      }
+    }
+    return result;
+  }
+}
+#endif

--- a/src/util/unicode.hpp
+++ b/src/util/unicode.hpp
@@ -24,6 +24,7 @@ namespace WiseIO {
     typedef unsigned char WUTF8;
     static const WUTF8 firstByteMark[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
     int result = 0;
+    unsigned char buf[4] = {0,0,0,0};
     for (InputIterator it = start; it != end; it++) {
       WUTF32 ch = *it;
       unsigned short bytesToWrite = 0;
@@ -49,7 +50,6 @@ namespace WiseIO {
         result = 1;
         break;
       }
-      unsigned char buf[4];
       switch (bytesToWrite) { /* note: everything falls through. */
       case 4: buf[3] = (WUTF8)((ch | byteMark) & byteMask); ch >>= 6;
       case 3: buf[2] = (WUTF8)((ch | byteMark) & byteMask); ch >>= 6;

--- a/tests/test_paratext.py
+++ b/tests/test_paratext.py
@@ -96,6 +96,26 @@ class TestBasicFiles:
             actual = paratext.load_csv_to_pandas(fn)
             assert_dictframe_almost_equal(actual, expected)
 
+    def test_basic_empty_cells_num(self):
+        filedata = b"""A,B,C,D,E,F
+#,1,#,#,2,#
+3,#,#,4,5,#
+6,#,#,#,#,#
+#,7,#,#,#,#
+#,#,8,#,#,#
+#,#,#,9,#,#
+#,#,#,#,10,#
+#,#,#,#,#,11
+#,#,12,#,#,13
+14,#,#,15,16,17
+"""
+        filedata = filedata.replace(b"#", b"")
+        with generate_tempfile(filedata) as fn:
+            expected = {"A": [0,3,6,0,0,0,0,0,0,14], "B": [1,0,0,7,0,0,0,0,0,0], "C": [0,0,0,0,8,0,0,0,12,0], "D": [0,4,0,0,0,9,0,0,0,15], "E": [2,5,0,0,0,0,10,0,0,16], "F": [0,0,0,0,0,0,0,11,13,17]}
+            logging.debug("filename: %s" % fn)
+            actual = paratext.load_csv_to_pandas(fn, number_only=True)
+            assert_dictframe_almost_equal(actual, expected)
+
 class TestMixedFiles:
 
     def run_case(self, num_rows, num_cats, num_floats, num_ints, num_threads):

--- a/tests/test_paratext.py
+++ b/tests/test_paratext.py
@@ -44,11 +44,15 @@ class TestBasicFiles:
                 yield self.do_basic_empty, file_body, num_threads
 
     def test_basic_ints(self):
-        for dtype in [np.float_, np.uint8]:
+        for dtype in [np.float_, np.int64]:
             for num_rows in [0, 1, 2, 3, 4, 5, 6, 10, 100, 1000]:
                 for num_cols in [1, 2, 3, 4, 5, 6, 10]:
-                    for num_threads in [0, 1, 2, 3, 4, 5, 6, 7, 8, 15, 20]:
-                        yield self.do_basic_nums, dtype, num_rows, num_cols, num_threads
+                    if num_rows * num_cols < 20:
+                        thread_set = range(0,30)
+                    else:
+                        thread_set = [0, 1, 2, 3, 4, 5, 6, 7, 8, 15, 20]
+                        for num_threads in thread_set:
+                            yield self.do_basic_nums, dtype, num_rows, num_cols, num_threads
 
     def test_basic_strange1(self):
         filedata = b"""A,B,C

--- a/tests/test_paratext.py
+++ b/tests/test_paratext.py
@@ -7,84 +7,10 @@ import numpy as np
 
 from nose_parameterized import parameterized
 
-class TestBasicFiles(unittest.TestCase):
+class TestBasicFiles:
 
-    @parameterized.expand([
-        ["1x0 uint8", 1, 0, np.uint8],
-        ["0x1 uint8", 0, 1, np.uint8],
-        ["1x1 uint8", 1, 1, np.uint8],
-        ["2x1 uint8", 2, 1, np.uint8],
-        ["3x1 uint8", 3, 1, np.uint8],
-        ["4x1 uint8", 4, 1, np.uint8],
-        ["5x1 uint8", 5, 1, np.uint8],
-        ["6x1 uint8", 6, 1, np.uint8],
-        ["0x2 uint8", 0, 2, np.uint8],
-        ["1x2 uint8", 1, 2, np.uint8],
-        ["2x2 uint8", 2, 2, np.uint8],
-        ["3x2 uint8", 3, 2, np.uint8],
-        ["4x2 uint8", 4, 2, np.uint8],
-        ["5x2 uint8", 5, 2, np.uint8],
-        ["6x2 uint8", 6, 2, np.uint8],
-        ["0x3 uint8", 0, 3, np.uint8],
-        ["1x3 uint8", 1, 3, np.uint8],
-        ["2x3 uint8", 2, 3, np.uint8],
-        ["3x3 uint8", 3, 3, np.uint8],
-        ["4x3 uint8", 4, 3, np.uint8],
-        ["5x3 uint8", 5, 3, np.uint8],
-        ["6x3 uint8", 6, 3, np.uint8],
-        ["0x4 uint8", 0, 4, np.uint8],
-        ["1x4 uint8", 1, 4, np.uint8],
-        ["2x4 uint8", 2, 4, np.uint8],
-        ["3x4 uint8", 3, 4, np.uint8],
-        ["4x4 uint8", 4, 4, np.uint8],
-        ["5x4 uint8", 5, 4, np.uint8],
-        ["6x4 uint8", 6, 4, np.uint8],
-        ["0x5 float",0, 5, np.uint8],
-        ["1x5 float",1, 5, np.uint8],
-        ["2x5 float",2, 5, np.uint8],
-        ["3x5 float",3, 5, np.uint8],
-        ["4x5 float",4, 5, np.uint8],
-        ["5x5 float",5, 5, np.uint8],
-        ["6x5 float",6, 5, np.uint8],
-        ["1x0 float",1, 0, np.float_],
-        ["0x1 float",0, 1, np.float_],
-        ["1x1 float",1, 1, np.float_],
-        ["2x1 float",2, 1, np.float_],
-        ["3x1 float",3, 1, np.float_],
-        ["4x1 float",4, 1, np.float_],
-        ["5x1 float",5, 1, np.float_],
-        ["6x1 float",6, 1, np.float_],
-        ["0x2 float",0, 2, np.float_],
-        ["1x2 float",1, 2, np.float_],
-        ["2x2 float",2, 2, np.float_],
-        ["3x2 float",3, 2, np.float_],
-        ["4x2 float",4, 2, np.float_],
-        ["5x2 float",5, 2, np.float_],
-        ["6x2 float",6, 2, np.float_],
-        ["0x3 float",0, 3, np.float_],
-        ["1x3 float",1, 3, np.float_],
-        ["2x3 float",2, 3, np.float_],
-        ["3x3 float",3, 3, np.float_],
-        ["4x3 float",4, 3, np.float_],
-        ["5x3 float",5, 3, np.float_],
-        ["6x3 float",6, 3, np.float_],
-        ["0x4 float",0, 4, np.float_],
-        ["1x4 float",1, 4, np.float_],
-        ["2x4 float",2, 4, np.float_],
-        ["3x4 float",3, 4, np.float_],
-        ["4x4 float",4, 4, np.float_],
-        ["5x4 float",5, 4, np.float_],
-        ["6x4 float",6, 4, np.float_],
-        ["0x5 float",0, 5, np.float_],
-        ["1x5 float",1, 5, np.float_],
-        ["2x5 float",2, 5, np.float_],
-        ["3x5 float",3, 5, np.float_],
-        ["4x5 float",4, 5, np.float_],
-        ["5x5 float",5, 5, np.float_],
-        ["6x5 float",6, 5, np.float_],
-    ])
-    def test_basic_ints(self, name, num_rows, num_columns, dtype):
-        keys = ["A", "B", "C", "D", "E", "F"]
+    def do_basic_nums(self, dtype, num_rows, num_columns, num_threads):
+        keys = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]
         keys = keys[0:num_columns]
         filedata = ','.join(keys[0:num_columns]) + "\n"
         expected = {}
@@ -100,9 +26,15 @@ class TestBasicFiles(unittest.TestCase):
                 expected[keys[k]].append(row_data[k])
         with generate_tempfile(filedata) as fn:
             print(fn)
-            actual = paratext.load_csv_to_pandas(fn)
+            actual = paratext.load_csv_to_pandas(fn, num_threads=num_threads)
             assert_dictframe_almost_equal(actual, expected)
 
+    def test_basic_ints(self):
+        for dtype in [np.float_, np.uint8]:
+            for num_rows in [0, 1, 2, 3, 4, 5, 6, 10, 100, 1000]:
+                for num_cols in [1, 2, 3, 4, 5, 6, 10]:
+                    for num_threads in [0, 1, 2, 3, 4, 5, 6, 7, 8, 15, 20]:
+                        yield self.do_basic_nums, dtype, num_rows, num_cols, num_threads
 
     def test_basic_strange1(self):
         filedata = """A,B,C
@@ -146,53 +78,47 @@ class TestBasicFiles(unittest.TestCase):
             actual = paratext.load_csv_to_pandas(fn)
             assert_dictframe_almost_equal(actual, expected)
 
+class TestMixedFiles:
 
-
-class TestHellFiles(unittest.TestCase):
-
-    @parameterized.expand([
-        ["hell rows=1 cols=1 num_threads=1", 1, 1, 1],
-        ["hell rows=1 cols=2 num_threads=1", 1, 2, 1],
-        ["hell rows=1 cols=3 num_threads=1", 1, 3, 1],
-        ["hell rows=1 cols=10 num_threads=1", 1, 10, 1],
-        ["hell rows=2 cols=1 num_threads=1", 2, 1, 1],
-        ["hell rows=2 cols=2 num_threads=1", 2, 2, 1],
-        ["hell rows=2 cols=3 num_threads=1", 2, 3, 1],
-        ["hell rows=2 cols=10 num_threads=1", 2, 10, 1],
-        ["hell rows=3 cols=1 num_threads=1", 3, 1, 1],
-        ["hell rows=3 cols=2 num_threads=1", 3, 2, 1],
-        ["hell rows=3 cols=3 num_threads=1", 3, 3, 1],
-        ["hell rows=3 cols=5 num_threads=1", 3, 5, 1],
-        ["hell rows=3 cols=10 num_threads=1", 3, 10, 1],
-        ["hell rows=4 cols=1 num_threads=1", 4, 1, 1],
-        ["hell rows=4 cols=2 num_threads=1", 4, 2, 1],
-        ["hell rows=4 cols=3 num_threads=1", 4, 3, 1],
-        ["hell rows=4 cols=5 num_threads=1", 4, 5, 1],
-        ["hell rows=4 cols=10 num_threads=1", 4, 10, 1],
-        ["hell rows=10 cols=1 num_threads=1", 10, 1, 1],
-        ["hell rows=10 cols=2 num_threads=1", 10, 2, 1],
-        ["hell rows=10 cols=3 num_threads=1", 10, 3, 1],
-        ["hell rows=10 cols=5 num_threads=1", 10, 5, 1],
-        ["hell rows=10 cols=10 num_threads=1", 10, 10, 1],
-        ["hell rows=100 cols=1 num_threads=1", 100, 1, 1],
-        ["hell rows=100 cols=2 num_threads=1", 100, 2, 1],
-        ["hell rows=100 cols=3 num_threads=1", 100, 3, 1],
-        ["hell rows=100 cols=5 num_threads=1", 100, 5, 1],
-        ["hell rows=100 cols=10 num_threads=1", 100, 10, 1],
-        ["hell rows=1000 cols=1 num_threads=1", 1000, 1, 1],
-        ["hell rows=1000 cols=2 num_threads=1", 1000, 2, 1],
-        ["hell rows=1000 cols=3 num_threads=1", 1000, 3, 1],
-        ["hell rows=1000 cols=5 num_threads=1", 1000, 5, 1],
-        ["hell rows=1000 cols=10 num_threads=1", 1000, 10, 1],
-        ["hell rows=3000 cols=1 num_threads=1", 3000, 1, 1],
-        ["hell rows=3000 cols=2 num_threads=1", 3000, 2, 1],
-        ["hell rows=3000 cols=3 num_threads=1", 3000, 3, 1],
-        ["hell rows=3000 cols=5 num_threads=1", 3000, 5, 1],
-        ["hell rows=3000 cols=10 num_threads=1", 3000, 10, 1],
-    ])
-    def test_hell_frame(self, name, rows, cols, num_threads):
-        expected = paratext.testing.generate_hell_frame(rows, cols)
+    def run_case(self, num_rows, num_cats, num_floats, num_ints, num_threads):
+        expected, types_df = paratext.testing.generate_mixed_frame(num_rows, num_floats, num_cats, num_ints)
         with generate_tempfilename() as fn:
             paratext.testing.save_frame(fn, expected)
-            actual = paratext.load_csv_to_pandas(fn, allow_quoted_newlines=True, out_encoding='utf-8')
+            actual = paratext.load_csv_to_pandas(fn, allow_quoted_newlines=True, out_encoding='utf-8', num_threads=num_threads)
             assert_dictframe_almost_equal(actual, expected)
+
+    def test_mixed_frame(self):
+        #assert_dictframe_almost_equal({}, {"hi":[1,2]})
+        for num_rows in [1, 2, 3, 5, 10, 100, 1000]:
+            for num_cats in [1, 3, 5]:
+                for num_floats in [1, 3, 5]:
+                    for num_ints in [50]:
+                        for num_threads in [1,2,3,5,10,20]:
+                            yield self.run_case, num_rows, num_cats, num_floats, num_ints, num_threads
+
+class TestHellFiles:
+
+    def do_hell_frame(self, frame_encoding, out_encoding, include_null, allow_quoted_newlines, rows, cols, num_threads):
+        print(num_threads)
+        expected = paratext.testing.generate_hell_frame(rows, cols, include_null=include_null, fmt=frame_encoding)
+        with generate_tempfilename() as fn:
+            print(fn)
+            paratext.testing.save_frame(fn, expected, allow_quoted_newlines, out_format=out_encoding)
+            actual = paratext.load_csv_to_pandas(fn, allow_quoted_newlines=allow_quoted_newlines, out_encoding=out_encoding, num_threads=num_threads, convert_null_to_space=not include_null)
+            assert_dictframe_almost_equal(actual, expected)
+
+    def test_hell_frame(self):
+        formatting = [("utf-8", "utf-8"),
+                      ("printable_ascii", "utf-8"),
+                      ("utf-8", "unknown"),
+                      ("arbitrary", "unknown"),
+                      ("arbitrary", "utf-8"),
+                      ("mixed", "unknown"),
+                      ("mixed", "utf-8")]
+        for (frame_encoding, out_encoding) in formatting:
+            for include_null in [False, True]:
+                for allow_quoted_newlines in [False, True]:
+                    for num_rows in [1,2,3,4,10,100,1000,3000]:
+                        for num_cols in [1,2,3,4,5,10,20,30]:
+                            for num_threads in [1]:#[1,2,3,4,5,10,20,30]:
+                                yield self.do_hell_frame, frame_encoding, out_encoding, include_null, allow_quoted_newlines, num_rows, num_cols, num_threads

--- a/tests/test_paratext.py
+++ b/tests/test_paratext.py
@@ -98,7 +98,7 @@ class TestMixedFiles:
         expected, types_df = paratext.testing.generate_mixed_frame(num_rows, num_floats, num_cats, num_ints)
         with generate_tempfilename() as fn:
             logging.debug("filename: %s" % fn)
-            paratext.serial.save_frame(fn, expected, allow_quoted_newlines=True)
+            paratext.serial.save_frame(fn, expected, allow_quoted_newlines=True, out_encoding='utf-8')
             actual = paratext.load_csv_to_pandas(fn, allow_quoted_newlines=True, out_encoding='utf-8', num_threads=num_threads)
             assert_dictframe_almost_equal(actual, expected)
 

--- a/tests/test_paratext.py
+++ b/tests/test_paratext.py
@@ -98,7 +98,7 @@ class TestMixedFiles:
         expected, types_df = paratext.testing.generate_mixed_frame(num_rows, num_floats, num_cats, num_ints)
         with generate_tempfilename() as fn:
             logging.debug("filename: %s" % fn)
-            paratext.serial.save_frame(fn, expected, allow_quoted_newlines)
+            paratext.serial.save_frame(fn, expected, allow_quoted_newlines=True)
             actual = paratext.load_csv_to_pandas(fn, allow_quoted_newlines=True, out_encoding='utf-8', num_threads=num_threads)
             assert_dictframe_almost_equal(actual, expected)
 

--- a/tests/test_paratext.py
+++ b/tests/test_paratext.py
@@ -1,0 +1,202 @@
+from contextlib import contextmanager
+import os
+import pandas.util.testing
+import unittest
+import paratext
+import numpy as np
+from tempfile import NamedTemporaryFile
+from nose_parameterized import parameterized
+
+@contextmanager
+def generate_tempfile(filedata):
+    f = NamedTemporaryFile(delete=False, prefix="paratext-tests")
+    f.write(filedata.encode("utf-8"))
+    name = f.name
+    f.close()
+    yield f.name
+    os.remove(name)
+
+def assert_seq_almost_equal(left, right):
+    left = np.asarray(left)
+    right = np.asarray(right)
+    if np.issubdtype(left.dtype, np.integer) and np.issubdtype(right.dtype, np.integer):
+        if not (left == right).all():
+            m = (left != right).mean() * 100
+            raise AssertionError("integer sequences mismatch: %5.5f%%" % (m,))
+    elif np.issubdtype(left.dtype, np.floating) and np.issubdtype(right.dtype, np.floating):
+        np.testing.assert_almost_equal(left, right)
+    else:
+        if np.issubdtype(left.dtype, np.floating):
+            left_float = left
+        else:
+            left_float = np.asarray(left, dtype=np.float_)
+        if np.issubdtype(right.dtype, np.floating):
+            right_float = right
+        else:
+            right_float = np.asarray(right, dtype=np.float_)
+        np.testing.assert_almost_equal(left_float, right_float)
+
+def assert_dictframe_almost_equal(left, right):
+    left_keys = set(left.keys())
+    right_keys = set(right.keys())
+    left_missing = right_keys - left_keys
+    right_missing = left_keys - right_keys
+    together = left_keys.intersection(right_keys)
+    msg = ""
+    for key in left_missing:
+        msg += "%s: missing on left\n" % key
+    for key in right_missing:
+        msg += "%s: missing on right\n" % key
+    for key in together:
+        try:
+            assert_seq_almost_equal(left[key], right[key])
+        except AssertionError as e:
+            msg += "\n Column %s: %s" % (key, e.args[0])
+    if len(msg) > 0:
+        raise AssertionError(msg)
+
+class TestBasicFiles(unittest.TestCase):
+
+    @parameterized.expand([
+        ["1x0 uint8", 1, 0, np.uint8],
+        ["0x1 uint8", 0, 1, np.uint8],
+        ["1x1 uint8", 1, 1, np.uint8],
+        ["2x1 uint8", 2, 1, np.uint8],
+        ["3x1 uint8", 3, 1, np.uint8],
+        ["4x1 uint8", 4, 1, np.uint8],
+        ["5x1 uint8", 5, 1, np.uint8],
+        ["6x1 uint8", 6, 1, np.uint8],
+        ["0x2 uint8", 0, 2, np.uint8],
+        ["1x2 uint8", 1, 2, np.uint8],
+        ["2x2 uint8", 2, 2, np.uint8],
+        ["3x2 uint8", 3, 2, np.uint8],
+        ["4x2 uint8", 4, 2, np.uint8],
+        ["5x2 uint8", 5, 2, np.uint8],
+        ["6x2 uint8", 6, 2, np.uint8],
+        ["0x3 uint8", 0, 3, np.uint8],
+        ["1x3 uint8", 1, 3, np.uint8],
+        ["2x3 uint8", 2, 3, np.uint8],
+        ["3x3 uint8", 3, 3, np.uint8],
+        ["4x3 uint8", 4, 3, np.uint8],
+        ["5x3 uint8", 5, 3, np.uint8],
+        ["6x3 uint8", 6, 3, np.uint8],
+        ["0x4 uint8", 0, 4, np.uint8],
+        ["1x4 uint8", 1, 4, np.uint8],
+        ["2x4 uint8", 2, 4, np.uint8],
+        ["3x4 uint8", 3, 4, np.uint8],
+        ["4x4 uint8", 4, 4, np.uint8],
+        ["5x4 uint8", 5, 4, np.uint8],
+        ["6x4 uint8", 6, 4, np.uint8],
+        ["0x5 float",0, 5, np.uint8],
+        ["1x5 float",1, 5, np.uint8],
+        ["2x5 float",2, 5, np.uint8],
+        ["3x5 float",3, 5, np.uint8],
+        ["4x5 float",4, 5, np.uint8],
+        ["5x5 float",5, 5, np.uint8],
+        ["6x5 float",6, 5, np.uint8],
+        ["1x0 float",1, 0, np.float_],
+        ["0x1 float",0, 1, np.float_],
+        ["1x1 float",1, 1, np.float_],
+        ["2x1 float",2, 1, np.float_],
+        ["3x1 float",3, 1, np.float_],
+        ["4x1 float",4, 1, np.float_],
+        ["5x1 float",5, 1, np.float_],
+        ["6x1 float",6, 1, np.float_],
+        ["0x2 float",0, 2, np.float_],
+        ["1x2 float",1, 2, np.float_],
+        ["2x2 float",2, 2, np.float_],
+        ["3x2 float",3, 2, np.float_],
+        ["4x2 float",4, 2, np.float_],
+        ["5x2 float",5, 2, np.float_],
+        ["6x2 float",6, 2, np.float_],
+        ["0x3 float",0, 3, np.float_],
+        ["1x3 float",1, 3, np.float_],
+        ["2x3 float",2, 3, np.float_],
+        ["3x3 float",3, 3, np.float_],
+        ["4x3 float",4, 3, np.float_],
+        ["5x3 float",5, 3, np.float_],
+        ["6x3 float",6, 3, np.float_],
+        ["0x4 float",0, 4, np.float_],
+        ["1x4 float",1, 4, np.float_],
+        ["2x4 float",2, 4, np.float_],
+        ["3x4 float",3, 4, np.float_],
+        ["4x4 float",4, 4, np.float_],
+        ["5x4 float",5, 4, np.float_],
+        ["6x4 float",6, 4, np.float_],
+        ["0x5 float",0, 5, np.float_],
+        ["1x5 float",1, 5, np.float_],
+        ["2x5 float",2, 5, np.float_],
+        ["3x5 float",3, 5, np.float_],
+        ["4x5 float",4, 5, np.float_],
+        ["5x5 float",5, 5, np.float_],
+        ["6x5 float",6, 5, np.float_],
+    ])
+    def test_basic_ints(self, name, num_rows, num_columns, dtype):
+        keys = ["A", "B", "C", "D", "E", "F"]
+        keys = keys[0:num_columns]
+        filedata = ','.join(keys[0:num_columns]) + "\n"
+        expected = {}
+        for key in keys:
+            expected[key] = []
+        for row in range(num_rows):
+            if np.issubdtype(dtype, np.integer):
+                row_data = [row*i for i in range(num_columns)]
+            else:
+                row_data = np.random.random((num_columns,))
+            filedata += ",".join([str(v) for v in row_data]) + "\n"
+            for k in range(len(keys)):
+                expected[keys[k]].append(row_data[k])
+        with generate_tempfile(filedata) as fn:
+            print(fn)
+            actual = paratext.load_csv_to_pandas(fn)
+            assert_dictframe_almost_equal(actual, expected)
+
+
+    @parameterized.expand([
+        ["foo", "a", "a",],
+        ["bar", "a", "b"],
+        ["lee", "b", "b"],
+    ])
+    def test_basic_3x3x(self, A, B, C):
+        filedata = u"""A,B,C
+1,4,7
+2,5,8
+3,6,9"""
+        with generate_tempfile(filedata) as fn:
+            expected = {"A": [1,2,3], "B": [4,5,6], "C": [7,8,9]}
+            print(fn)
+            actual = paratext.load_csv_to_pandas(fn)
+            assert_dictframe_almost_equal(actual, expected)
+
+    def test_basic_3x2x(self):
+        filedata = u"""A,B,C
+1,4,7
+2,5,8
+"""
+        with generate_tempfile(filedata) as fn:
+            expected = {"A": [1,2], "B": [4,5], "C": [7,8]}
+            print(fn)
+            actual = paratext.load_csv_to_pandas(fn)
+            assert_dictframe_almost_equal(actual, expected)
+
+    def test_basic_3x1x(self):
+        filedata = u"""A,B,C
+1,4,7
+"""
+        with generate_tempfile(filedata) as fn:
+            expected = {"A": [1], "B": [4], "C": [7]}
+            print(fn)
+            actual = paratext.load_csv_to_pandas(fn)
+            assert_dictframe_almost_equal(actual, expected)
+
+
+    def test_basic_3x1x(self):
+        filedata = u"""A,B,C
+"""
+        with generate_tempfile(filedata) as fn:
+            expected = {"A": [], "B": [], "C": []}
+            print(fn)
+            actual = paratext.load_csv_to_pandas(fn)
+            assert_dictframe_almost_equal(actual, expected)
+
+

--- a/tests/test_paratext.py
+++ b/tests/test_paratext.py
@@ -23,7 +23,7 @@ class TestBasicFiles:
             filedata += ",".join([str(v) for v in row_data]) + "\n"
             for k in range(len(keys)):
                 expected[keys[k]].append(row_data[k])
-        with generate_tempfile(filedata) as fn:
+        with generate_tempfile(filedata.encode("utf-8")) as fn:
             logging.debug("filename: %s" % fn)
             actual = paratext.load_csv_to_pandas(fn, num_threads=num_threads)
             assert_dictframe_almost_equal(actual, expected)
@@ -36,8 +36,8 @@ class TestBasicFiles:
             assert_dictframe_almost_equal(actual, expected)
 
     def test_basic_empty(self):
-        file_bodies = ["", "\n", "\n\n", " ", " \n", " \n   \n \n", "\n  \n", "\v\t \n", "\n\n\n", "\n\n\n\n"]
-        file_bodies += ["\r\n", "\r\n\r\n", " ", " \r\n", " \r\n   \r\n \r\n", "\r\n  \r\n", "\r\v\t \r\n", "\r\n\r\n\r\n", "\r\n\r\n\r\n\r\n"]
+        file_bodies = [b"", b"\n", b"\n\n", b" ", b" \n", b" \n   \n \n", b"\n  \n", b"\v\t \n", b"\n\n\n", b"\n\n\n\n"]
+        file_bodies += [b"\r\n", b"\r\n\r\n", b" ", b" \r\n", b" \r\n   \r\n \r\n", b"\r\n  \r\n", b"\r\v\t \r\n", b"\r\n\r\n\r\n", b"\r\n\r\n\r\n\r\n"]
         for file_body in file_bodies:
             for num_threads in [1]:
                 yield self.do_basic_empty, file_body, num_threads
@@ -50,7 +50,7 @@ class TestBasicFiles:
                         yield self.do_basic_nums, dtype, num_rows, num_cols, num_threads
 
     def test_basic_strange1(self):
-        filedata = """A,B,C
+        filedata = b"""A,B,C
 "\\\"","",7
 "\\\\","X",8
 "\n","\\\\\\"",9"""
@@ -61,7 +61,7 @@ class TestBasicFiles:
             assert_dictframe_almost_equal(actual, expected)
 
     def test_basic_3x2x(self):
-        filedata = u"""A,B,C
+        filedata = b"""A,B,C
 1,4,7
 2,5,8
 """
@@ -72,7 +72,7 @@ class TestBasicFiles:
             assert_dictframe_almost_equal(actual, expected)
 
     def test_basic_3x1x(self):
-        filedata = u"""A,B,C
+        filedata = b"""A,B,C
 1,4,7
 """
         with generate_tempfile(filedata) as fn:
@@ -83,7 +83,7 @@ class TestBasicFiles:
 
 
     def test_basic_3x0x(self):
-        filedata = u"""A,B,C
+        filedata = b"""A,B,C
 """
         with generate_tempfile(filedata) as fn:
             expected = {"A": [], "B": [], "C": []}

--- a/tests/test_paratext.py
+++ b/tests/test_paratext.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import paratext.testing
+import paratext.serial
 from paratext.testing import assert_dictframe_almost_equal, generate_tempfile, generate_tempfilename
 import pandas.util.testing
 import numpy as np
@@ -97,7 +98,7 @@ class TestMixedFiles:
         expected, types_df = paratext.testing.generate_mixed_frame(num_rows, num_floats, num_cats, num_ints)
         with generate_tempfilename() as fn:
             logging.debug("filename: %s" % fn)
-            paratext.testing.save_frame(fn, expected)
+            paratext.serial.save_frame(fn, expected, allow_quoted_newlines)
             actual = paratext.load_csv_to_pandas(fn, allow_quoted_newlines=True, out_encoding='utf-8', num_threads=num_threads)
             assert_dictframe_almost_equal(actual, expected)
 
@@ -115,7 +116,7 @@ class TestHellFiles:
         expected = paratext.testing.generate_hell_frame(rows, cols, include_null=include_null, fmt=frame_encoding)
         with generate_tempfilename() as fn:
             logging.debug("filename: %s" % fn)
-            paratext.testing.save_frame(fn, expected, allow_quoted_newlines, out_format=out_encoding, dos=dos)
+            paratext.serial.save_frame(fn, expected, allow_quoted_newlines, out_encoding=out_encoding, dos=dos)
             actual = paratext.load_csv_to_pandas(fn, allow_quoted_newlines=allow_quoted_newlines, out_encoding=out_encoding, num_threads=num_threads, convert_null_to_space=not include_null)
             assert_dictframe_almost_equal(actual, expected)
 

--- a/tests/test_paratext.py
+++ b/tests/test_paratext.py
@@ -82,7 +82,7 @@ class TestBasicFiles:
             assert_dictframe_almost_equal(actual, expected)
 
 
-    def test_basic_3x1x(self):
+    def test_basic_3x0x(self):
         filedata = u"""A,B,C
 """
         with generate_tempfile(filedata) as fn:
@@ -102,7 +102,7 @@ class TestMixedFiles:
             assert_dictframe_almost_equal(actual, expected)
 
     def test_mixed_frame(self):
-        for num_rows in [1, 2, 3, 5, 10, 100, 1000]:
+        for num_rows in [0, 1, 2, 3, 5, 10, 100, 1000]:
             for num_cats in [1, 3, 5]:
                 for num_floats in [1, 3, 5]:
                     for num_ints in [0, 1, 5, 10, 50]:
@@ -131,7 +131,7 @@ class TestHellFiles:
             for (frame_encoding, out_encoding) in formatting:
                 for include_null in [False, True]:
                     for allow_quoted_newlines in [False, True]:
-                        for num_rows in [1,2,3,4,10,100,1000,3000]:
+                        for num_rows in [0, 1,2,3,4,10,100,1000,3000]:
                             for num_cols in [1,2,3,4,5,10,20,30]:
                                 for num_threads in [1,2,3,4,5,8,10,20,30]:
                                     yield self.do_hell_frame, dos, frame_encoding, out_encoding, include_null, allow_quoted_newlines, num_rows, num_cols, num_threads

--- a/tests/test_paratext.py
+++ b/tests/test_paratext.py
@@ -5,8 +5,6 @@ from paratext.testing import assert_dictframe_almost_equal, generate_tempfile, g
 import pandas.util.testing
 import numpy as np
 
-from nose_parameterized import parameterized
-
 class TestBasicFiles:
 
     def do_basic_nums(self, dtype, num_rows, num_columns, num_threads):

--- a/tests/test_paratext.py
+++ b/tests/test_paratext.py
@@ -131,7 +131,7 @@ class TestHellFiles:
             for (frame_encoding, out_encoding) in formatting:
                 for include_null in [False, True]:
                     for allow_quoted_newlines in [False, True]:
-                        for num_rows in [0, 1,2,3,4,10,100,1000,3000]:
-                            for num_cols in [1,2,3,4,5,10,20,30]:
-                                for num_threads in [1,2,3,4,5,8,10,20,30]:
+                        for num_rows in [0, 1,2,3,4,10,100,600]:
+                            for num_cols in [1,2,3,4,5,10]:
+                                for num_threads in [1,2,4,8,16]:
                                     yield self.do_hell_frame, dos, frame_encoding, out_encoding, include_null, allow_quoted_newlines, num_rows, num_cols, num_threads


### PR DESCRIPTION
@pdbaines (wise.io) requested this feature be moved up in priority.

The following escape characters are supported:

  - `\n`: newlines
  - `\t`: tabs
  - `\r`: carriage returns
  - `\b`: backspace
  - `\f`: form feed
  - `\xYY`: a byte represented by hex digits YY
  - `\uYYYY`: a unicode literal represented by hex digits YYYY
  - `\0`: null character

Null characters are converted to spaces for security reasons.