### PR TITLE
Work for #24 (Windows support)

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -4,7 +4,11 @@ import json
 
 # First, check for the presence of swig, which we will need to build
 # the Python bindings.
-p = subprocess.Popen(["which", "swig"])
+if sys.platform == "win32":
+    cmd = "where" # no 'which' command on windows
+else:
+    cmd = "which"
+p = subprocess.Popen([cmd, "swig"])
 p.communicate("")
 if p.returncode != 0:
     print("Error: you must install SWIG first.")
@@ -23,6 +27,11 @@ elif sys.platform.startswith("linux"):
     extra_compile_args += []
     extra_link_args += []
     extra_libraries += []
+elif sys.platform == "win32":
+    extra_link_args = []
+    extra_compile_args = []
+    extra_libraries = []
+    
 
 if len(set(('develop', 'release', 'bdist_egg', 'bdist_rpm',
             'bdist_wininst', 'install_egg_info', 'build_sphinx',

--- a/python/setup.py
+++ b/python/setup.py
@@ -16,7 +16,7 @@ if p.returncode != 0:
 
 # The multi-threaded reader will core dump unless -pthread is given.
 extra_link_args = []
-extra_compile_args = ["-std=c++11", "-Wall", "-Wextra", "-pthread"]
+extra_compile_args = ["stdc++", "-std=c++11", "-Wall", "-Wextra", "-pthread"]
 extra_libraries = []
 
 if sys.platform == 'darwin':
@@ -29,7 +29,7 @@ elif sys.platform.startswith("linux"):
     extra_libraries += []
 elif sys.platform == "win32":
     extra_link_args = []
-    extra_compile_args = []
+    extra_compile_args = ["/Wall"]
     extra_libraries = []
     
 
@@ -93,7 +93,7 @@ See README
                              extra_link_args = extra_link_args,
                              extra_compile_args = extra_compile_args,
                              include_dirs=['../src/'],
-                             libraries=["stdc++"] + extra_libraries),
+                             libraries = extra_libraries),
                    ],
       py_modules=["paratext_internal"],
       author="Damian Eads",

--- a/python/setup.py
+++ b/python/setup.py
@@ -16,17 +16,17 @@ if p.returncode != 0:
 
 # The multi-threaded reader will core dump unless -pthread is given.
 extra_link_args = []
-extra_compile_args = ["stdc++", "-std=c++11", "-Wall", "-Wextra", "-pthread"]
+extra_compile_args = ["-std=c++11", "-Wall", "-Wextra", "-pthread"]
 extra_libraries = []
 
 if sys.platform == 'darwin':
     extra_compile_args += ["-m64", "-D_REENTRANT"]
     extra_link_args += []
-    extra_libraries += []
+    extra_libraries += ["stdc++"]
 elif sys.platform.startswith("linux"):
     extra_compile_args += []
     extra_link_args += []
-    extra_libraries += []
+    extra_libraries += ["stdc++"]
 elif sys.platform == "win32":
     extra_link_args = []
     extra_compile_args = ["/Wall"]

--- a/src/csv/colbased_worker.hpp
+++ b/src/csv/colbased_worker.hpp
@@ -34,6 +34,7 @@
 #include <fstream>
 #include <exception>
 #include <stdexcept>
+#include <locale>
 
 namespace ParaText {
 
@@ -86,7 +87,11 @@ public:
     size_t current = begin;
     size_t spos_line = begin, epos_line = begin;
     const size_t block_size = params.block_size;
+#ifndef _WIN32
     char buf[block_size];
+#else
+    char *buf = (char *)_malloca(block_size);
+#endif
     in.seekg(current, std::ios_base::beg);
     definitely_string_ = false;
 #ifdef PARALOAD_DEBUG
@@ -267,7 +272,8 @@ public:
       }
       if (!handled) {
         if (i < token_.size()) {
-          integer_possible = std::isdigit(token_[i]);
+          const std::locale loc("");
+          integer_possible = std::isdigit(token_[i], loc);
           i++;
           float_possible = integer_possible, exp_possible = integer_possible;
           while (i < token_.size() && integer_possible) {

--- a/src/csv/header_parser.hpp
+++ b/src/csv/header_parser.hpp
@@ -101,7 +101,11 @@ namespace CSV {
       std::string token;
       size_t current = 0;
       size_t block_size = 4096;
+#ifndef _WIN32
       char buf[block_size];
+#else
+      char *buf = (char *)_malloca(block_size);
+#endif
       char quote_started = 0;
       in_.seekg(0, std::ios_base::beg);
       while (current < length_) {

--- a/src/csv/parallel.hpp
+++ b/src/csv/parallel.hpp
@@ -51,7 +51,7 @@ F parallel_for_each(Iterator first, Iterator last, size_t suggested_num_threads,
     return std::move(f);
   }
   const size_t num_threads =
-      std::min(std::max(1UL, suggested_num_threads), num_elements);
+      std::min(std::max(1UL, (unsigned long)suggested_num_threads), (unsigned long)num_elements);
   const std::size_t elements_thread = num_elements / num_threads;
   const std::size_t excess = num_elements % num_threads;
 

--- a/src/diagnostic/memcopy.hpp
+++ b/src/diagnostic/memcopy.hpp
@@ -33,7 +33,10 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+#ifndef _WIN32
+    #include <unistd.h>
+#endif
 #include <thread>
 #include <sstream>
 
@@ -70,7 +73,11 @@ public:
     std::ifstream in;
     in.open(filename.c_str());
     const size_t block_size = block_size_;
+#ifndef _WIN32
     char buf[block_size];
+#else
+    char *buf = (char *)_malloca(block_size);
+#endif
     in.seekg(chunk_start_, std::ios_base::beg);
     size_t current = chunk_start_;
     while (current <= chunk_end_) {

--- a/src/diagnostic/newline_counter.hpp
+++ b/src/diagnostic/newline_counter.hpp
@@ -33,7 +33,10 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+#ifndef _WIN32
+    #include <unistd.h>
+#endif
 #include <thread>
 #include <sstream>
 
@@ -70,7 +73,11 @@ public:
     std::ifstream in;
     in.open(filename.c_str());
     const size_t block_size = block_size_;
+#ifndef _WIN32
     char buf[block_size];
+#else
+    char *buf = (char *)_malloca(block_size);
+#endif
     in.seekg(chunk_start_, std::ios_base::beg);
     size_t current = chunk_start_;
     num_newlines_ = 0;

--- a/src/diagnostic/parse_and_sum.hpp
+++ b/src/diagnostic/parse_and_sum.hpp
@@ -75,7 +75,11 @@ public:
     std::ifstream in;
     in.open(filename.c_str());
     const size_t block_size = block_size_;
-    char buf[block_size];
+#ifndef _WIN32
+      char buf[block_size];
+#else
+      char *buf = (char *)_malloca(block_size);
+#endif
     in.seekg(chunk_start_, std::ios_base::beg);
     size_t current = chunk_start_;
     sums_.resize(num_columns_);

--- a/src/diagnostic/parse_and_sum.hpp
+++ b/src/diagnostic/parse_and_sum.hpp
@@ -33,7 +33,10 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+#ifndef _WIN32
+    #include <unistd.h>
+#endif
 #include <thread>
 #include <sstream>
 

--- a/src/generic/chunker.hpp
+++ b/src/generic/chunker.hpp
@@ -33,7 +33,9 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
+#ifndef _WIN32
+    #include <unistd.h>
+#endif
 #include <thread>
 #include <sstream>
 

--- a/src/util/strings.hpp
+++ b/src/util/strings.hpp
@@ -69,7 +69,8 @@
    */
   template <class Iterator>
   inline Iterator eat_whitespace(Iterator begin, Iterator end) {
-    while (begin != end && std::isspace(*begin)) { ++begin; }
+    const std::locale loc("");
+    while (begin != end && std::isspace(*begin, loc)) { ++begin; }
     return begin;
   }
 


### PR DESCRIPTION
This addresses windows support (#24) to the point that paratext is able to compile on windows using VS2015 (MSVC 1900) and python 3.5.

However, running on windows it just seems to hang when loading a csv, e.g:

```
paratext.load_csv_to_dict("file://C:/temp/exposures_105k_lines.csv")
```

Functionality on linux is unaltered - still works fine and the above call returns in a couple of seconds. If anyone has any ideas of what might be happening on windows that would be helpful!
