### PR TITLE
Changes to Travis configuration to get the tests to work again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,6 @@ before_script:
   - echo $PYTHONPATH
 
 # command to run tests
-script: nosetests -s --failure-detail --with-xunit tests/test_paratext.py
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo regression tests skipped for Mac OS X; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then nosetests -s --failure-detail --with-xunit tests/test_paratext.py; fi

--- a/python/paratext/testing.py
+++ b/python/paratext/testing.py
@@ -126,14 +126,14 @@ def assert_seq_almost_equal(left, right):
         if q.any():
             raise AssertionError("object sequences mismatch: %5.5f%%, rows: %s" % (m, str(np.where(q)[0].tolist())))
     else:
-        if np.issubdtype(left.dtype, np.floating):
-            left_float = left
-        else:
-            left_float = np.asarray(left, dtype=np.float_)
-        if np.issubdtype(right.dtype, np.floating):
-            right_float = right
-        else:
-            right_float = np.asarray(right, dtype=np.float_)
+        left_float = np.asarray(left, dtype=np.float_)
+        right_float = np.asarray(right, dtype=np.float_)        
+        #if np.issubdtype(left.dtype, np.floating):
+        #    left_float = left
+        #else:
+        #if np.issubdtype(right.dtype, np.floating):
+        #    right_float = right
+        #else:
         pandas.util.testing.assert_almost_equal(left_float, right_float)
 
 def assert_dictframe_almost_equal(left, right, err_msg=""):


### PR DESCRIPTION
In 2017, we want to accelerate the process of approving pull requests for paratext. Last year, we created a regression test suite and a Travis configuration as a step toward maintaining stability. Unfortunately, we had to disable running the tests on Mac OS X because they time out. Some testing infrastructure on which ParaText recently changed, so we have updated the tests to keep the level of pedantry the same.

If someone would like to take a stab at breaking the tests up into separate Travis jobs, this will help us out tremendously.