### PR TITLE
Support for iterating over a text column (supercedes #34)

### DIFF
--- a/src/csv/colbased_chunk.hpp
+++ b/src/csv/colbased_chunk.hpp
@@ -180,6 +180,11 @@ namespace CSV {
       return cat_data_.get<size_t>(i);
     }
 
+    template <class T, bool Numeric>
+    inline typename std::enable_if<std::is_same<std::string, T>::value && !Numeric, T>::type get(size_t i) const {
+      return text_data_[i];
+    }
+
     const std::vector<std::string> &get_cat_keys() const {
       return cat_keys_;
     }


### PR DESCRIPTION
```
ParaText::CSV::ColBasedLoader loader;
loader.force_semantics("Name", ParaText::Semantics::TEXT);
ParaText::ParseParams params;
params.num_threads=1;
loader.load("earthquakes.csv", params);
for (auto it = loader.column_begin<std::string, false>(0); it != loader.column_end<std::string, false>(0); it++) {
  std::cout << *it << std::endl;
}
```