### PR TITLE
Implement file chunk-based reading (#45).

### DIFF
--- a/src/generic/parse_params.hpp
+++ b/src/generic/parse_params.hpp
@@ -48,7 +48,7 @@ namespace ParaText {
   };
 
   struct ParseParams {
-    ParseParams() : no_header(false), number_only(false), convert_null_to_space(true), block_size(32768), num_threads(16), allow_quoted_newlines(false),  max_level_name_length(std::numeric_limits<size_t>::max()), max_levels(std::numeric_limits<size_t>::max()), compression(Compression::NONE), parser_type(ParserType::COL_BASED) {}
+    ParseParams() : no_header(false), number_only(false), convert_null_to_space(true), block_size(32768), num_threads(16), allow_quoted_newlines(false),  max_level_name_length(std::numeric_limits<size_t>::max()), max_levels(std::numeric_limits<size_t>::max()), compression(Compression::NONE), parser_type(ParserType::COL_BASED), chunked_file_reading(false), file_chunk_size(0) {}
     bool no_header;
     bool number_only;
     bool compute_sum;
@@ -60,7 +60,8 @@ namespace ParaText {
     size_t max_levels;
     Compression compression;
     ParserType parser_type;
+    bool chunked_file_reading;
+    size_t file_chunk_size;
   };
-
 }
 #endif


### PR DESCRIPTION
Hello,

We needed the ability to parse larger-than-memory CSV files, so this is my attempt at implementing that (issue #45). It's used something like this:

    ParaText::CSV::ColBasedLoader loader;
    ParaText::ParseParams params;
    params.num_threads = 4;
    params.chunked_file_reading = true;
    params.file_chunk_size = 1024 * 1024; // Approximate number of bytes to read from the input file

    loader.load(inputfile, params);
    do {
      std::vector<float> col0vals;
      auto inserter = std::back_inserter(col0vals);
      loader.copy_column<decltype(inserter), size_t>(0, inserter);
    } while (loader.load_next());

I'm grateful for any feedback on this, and I'd be happy to make any changes you guys may want.