### PR TITLE
try thread_local on temporary string when doing map lookups

### DIFF
--- a/src/csv/colbased_chunk.hpp
+++ b/src/csv/colbased_chunk.hpp
@@ -118,13 +118,17 @@ namespace CSV {
         else {
           //std::cout << "[" << std::string(begin, end);
           convert_to_cat_or_text();
-          std::string key(begin, end);
+          static thread_local std::string key;
+          key.insert(key.begin(), begin, end);
           add_cat_data(key);
+          key.clear();
         }
       }
       else {
-        std::string key(begin, end);
+        static thread_local std::string key;
+        key.insert(key.begin(), begin, end);
         add_cat_data(key);
+        key.clear();
       }
     }
 


### PR DESCRIPTION
#include<stdio.h>


int contador (int x, int y){
	
	if (x<=y){
		
		return contador (x+1, y);
		printf("%d os valores ",x);
		
		
		
	}
	
	
	
}



int main (){
	
	int f,c, resultado;
	printf("digite o começo");
	scanf("%d",&c);
	
	printf("digite o final");
	scanf("%d", &f);
	
	
	contador(c,f);
	resultado = contador (c,f);
	
	//printf("%d", resultado);
	
	
	
}