### PR TITLE
get_as_X should return type X

### DIFF
--- a/src/python/python_input.hpp
+++ b/src/python/python_input.hpp
@@ -132,7 +132,7 @@ namespace ParaText {
   }
   
   template <class T>
-  typename std::enable_if<std::is_arithmetic<T>::value, float>::type
+  typename std::enable_if<std::is_arithmetic<T>::value, long>::type
   get_as_long(const T &t, size_t item_size) {
     (void)item_size;
     return (long long)t;
@@ -140,7 +140,7 @@ namespace ParaText {
   
   
   template <class T>
-  typename std::enable_if<std::is_arithmetic<T>::value, float>::type
+  typename std::enable_if<std::is_arithmetic<T>::value, bool>::type
   get_as_bool(const T &t, size_t item_size) {
     (void)item_size;
     return (bool)t;


### PR DESCRIPTION
#include<stdio.h>




main(){
	
	
	int i, j, tamanho;
	int vetor[30];
	int auxiliar;
	
	
	
	printf("digite o tamanho");
	scanf("%d",&tamanho);
	
	
	for (i=0;i<=tamanho;i++){
		
		
		printf("digite um valor vetor[%d] \n \n ", i);
		scanf("%d",&vetor[i]);
	}
	
	
	  for (i=0;i<=tamanho-1;i++){
	  	
	  		for (j=i+1;j<=tamanho; j++){
	  			
	  			 if ( vetor[i]>vetor[j]){
	  			 	
	  			 	
	  			 	
	  			 	vetor[i] = auxiliar;
					   vetor[i]= vetor[j];
					   vetor[j] = auxiliar;				   
					   
					   

					   
					   
					   
					   }
	  			
	  			
			  }
	  	
	  	
	  }
            for (i=0;i<=tamanho; i++){
            	
            	printf("\n\n o vetor ordenado eh vetor[%d]", vetor[i]);
	
		
		
			}	
			
			
}